### PR TITLE
Additional OS Targets for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ jdk:
 os:
   - linux
   - osx
+
+after_success:
+  - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk:
   - oraclejdk7
   - openjdk6
   
+os:
+  - linux
+  - osx

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,25 @@
 						<dependenciesAsLibraries>true</dependenciesAsLibraries>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.eluder.coveralls</groupId>
+					<artifactId>coveralls-maven-plugin</artifactId>
+					<version>3.1.0</version>
+					<configuration>
+						<sourceEncoding>UTF-8</sourceEncoding>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>cobertura-maven-plugin</artifactId>
+					<version>2.6</version>
+					<configuration>
+						<format>xml</format>
+						<maxmem>256m</maxmem>
+						<!-- aggregated reports for multi-module projects -->
+						<aggregate>true</aggregate>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
In order to test against Mac OS X and therefore determine if #371 is fixed, add the 'os' to .travis.yml

DISCLAIMER: The psi-probe/psi-probe repository will need to be featured flagged for multi-os.  This can be accomplished by following the directions in this blog post.  http://blog.travis-ci.com/2014-05-13-multi-os-feature-available/  

This pull request will not break CI builds, as Travis simply ignores the additional OS settings.  Integration build can be seen here https://travis-ci.org/jander99/psi-probe with this comparison https://github.com/jander99/psi-probe/compare/d27d8ec43d93...b92ce1bfbb06