### PR TITLE
Fixed #411 Tomcat 7.0.54 Psi probe not listing global datasource

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
@@ -129,7 +129,16 @@ public class ResourceResolverBean implements ResourceResolver {
         if (contextBound) {
             try {
                 String jndiName = resolveJndiName(resource.getName(), global);
-                Object o = new InitialContext().lookup(jndiName);
+                Thread currentThread = Thread.currentThread();
+                ClassLoader currentClassLoader = currentThread.getContextClassLoader();
+                ClassLoader standardClassLoader = currentClassLoader.getParent();
+                currentThread.setContextClassLoader(standardClassLoader);
+                Object o;
+                try {
+                    o = new InitialContext().lookup(jndiName);
+                } finally {
+                    currentThread.setContextClassLoader(currentClassLoader);
+                }
                 resource.setLookedUp(true);
                 for (Iterator it = datasourceMappers.iterator(); it.hasNext();) {
                     DatasourceAccessor accessor = (DatasourceAccessor) it.next();


### PR DESCRIPTION
As described in tomcat [GlobalNamingResources](http://tomcat.apache.org/tomcat-7.0-doc/config/globalresources.html) docs, "resources defined in this element are <b>not</b> visible in the per-web-application contexts unless you explicitly link them with <ResourceLink> elements".

Tomcat's new behavior is actually the right one. I tried to track the tomcat svn commit that change it, without success. Later I check how Tomcat configure the JNDI and how the lookup are done. It binds the web application JNDI Context to the web application classloader, while the Global Resources are listed in the Common Classloader.

This fix consist of changing the current thread classloader during the lookup to the common classloader and later change it back to the original web classloader.