### PR TITLE
Update #394 Tomcat 8 Psi probe not listing global and application datasources

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
@@ -125,7 +125,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
     public void unbindFromContext(Context context) 
         throws NamingException {
 		Object token = null;
-        ContextBindings.bindClassLoader(context, token);
+        ContextBindings.unbindClassLoader(context, token, Thread.currentThread().getContextClassLoader());
     }
 	
     public Context findContext(String name) {

--- a/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
@@ -22,12 +22,14 @@ import java.util.Set;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
+import javax.naming.NamingException;
 
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.Host;
 import org.apache.catalina.core.StandardContext;
+import org.apache.naming.ContextBindings;
 import org.apache.commons.lang.reflect.MethodUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -104,6 +106,28 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
         }
     }
 
+	/**
+     * Binds a naming context to the current thread's classloader.
+     * 
+     * @param context the catalina context
+     */
+    public void bindToContext(Context context) 
+        throws NamingException {
+		Object token = null;
+        ContextBindings.bindClassLoader(context, token, Thread.currentThread().getContextClassLoader());
+    }
+	
+	/**
+     * Unbinds a naming context from the current thread's classloader.
+     * 
+     * @param context the catalina context
+     */
+    public void unbindFromContext(Context context) 
+        throws NamingException {
+		Object token = null;
+        ContextBindings.bindClassLoader(context, token);
+    }
+	
     public Context findContext(String name) {
         String safeName = formatContextName(name);
         if (safeName == null) {

--- a/core/src/main/java/com/googlecode/psiprobe/beans/JBossResourceResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/JBossResourceResolverBean.java
@@ -136,7 +136,7 @@ public class JBossResourceResolverBean implements ResourceResolver {
         return new ArrayList();
     }
 
-    public boolean resetResource(Context context, String resourceName) throws NamingException {
+    public boolean resetResource(Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException {
         try {
             ObjectName poolOName = new ObjectName("jboss.jca:service=ManagedConnectionPool,name="+resourceName);
             MBeanServer server = getMBeanServer();
@@ -155,7 +155,7 @@ public class JBossResourceResolverBean implements ResourceResolver {
         }
     }
 
-    public DataSource lookupDataSource(Context context, String resourceName) throws NamingException {
+    public DataSource lookupDataSource(Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException {
         throw new UnsupportedOperationException("This feature has not been implemented for JBoss server yet.");
     }
 

--- a/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolver.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolver.java
@@ -55,7 +55,7 @@ public interface ResourceResolver {
      *
      * @return true if the servlet container supports datasource lookup
      *
-     * @see #lookupDataSource(org.apache.catalina.Context, java.lang.String)
+     * @see #lookupDataSource(org.apache.catalina.Context, java.lang.String, com.googlecode.psiprobe.beans.ContainerWrapperBean)
      */
     boolean supportsDataSourceLookup();
 
@@ -63,9 +63,9 @@ public interface ResourceResolver {
 
     List getApplicationResources (Context context, ContainerWrapperBean containerWrapper) throws NamingException;
 
-    boolean resetResource (Context context, String resourceName) throws NamingException;
+    boolean resetResource (Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException;
 
-    DataSource lookupDataSource(Context context, String resourceName) throws NamingException;
+    DataSource lookupDataSource(Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException;
 
     /**
      * Method that gets {@link MBeanServer} instance that is "default" for the

--- a/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
@@ -22,19 +22,22 @@ import javax.naming.NamingException;
 import javax.sql.DataSource;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Server;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.modeler.Registry;
-import org.apache.naming.ContextBindings;
+import org.apache.catalina.core.StandardServer;
 
 import com.googlecode.psiprobe.model.ApplicationResource;
 import com.googlecode.psiprobe.model.DataSourceInfo;
+import com.googlecode.psiprobe.AbstractTomcatContainer;
 
 /**
  * 
  * @author Vlad Ilyushchenko
  * @author Andy Shapoval
  * @author Mark Lewis
+ * @author Henry Caballero
  */
 public class ResourceResolverBean implements ResourceResolver {
 
@@ -45,13 +48,13 @@ public class ResourceResolverBean implements ResourceResolver {
      * The default resource prefix for JNDI objects in the global scope:
      * <code>java:</code>.
      */
-    public static final String DEFAULT_GLOBAL_RESOURCE_PREFIX = "java:";
+    public static final String DEFAULT_GLOBAL_RESOURCE_PREFIX = "";
 
     /**
      * The default resource prefix for objects in a private application scope:
      * <code>java:comp/env/</code>.
      */
-    public static final String DEFAULT_RESOURCE_PREFIX = DEFAULT_GLOBAL_RESOURCE_PREFIX + "comp/env/";
+    public static final String DEFAULT_RESOURCE_PREFIX = DEFAULT_GLOBAL_RESOURCE_PREFIX + "java:comp/env/";
 
     private List datasourceMappers;
 
@@ -95,9 +98,9 @@ public class ResourceResolverBean implements ResourceResolver {
             logger.info("Reading CONTEXT " + context.getName());
 
             boolean contextBound = false;
-
+			
             try {
-                ContextBindings.bindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+                ((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).bindToContext(context);
                 contextBound = true;
             } catch (NamingException e) {
                 logger.error("Cannot bind to context. useNaming=false ?");
@@ -114,7 +117,7 @@ public class ResourceResolverBean implements ResourceResolver {
             	
             } finally {
                 if (contextBound) {
-                    ContextBindings.unbindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+					((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).unbindFromContext(context);
                 }
             }
         }
@@ -128,17 +131,9 @@ public class ResourceResolverBean implements ResourceResolver {
         DataSourceInfo dataSourceInfo = null;
         if (contextBound) {
             try {
+				javax.naming.Context ctx = !global ? new InitialContext() : getGlobalNamingContext();
                 String jndiName = resolveJndiName(resource.getName(), global);
-                Thread currentThread = Thread.currentThread();
-                ClassLoader currentClassLoader = currentThread.getContextClassLoader();
-                ClassLoader standardClassLoader = currentClassLoader.getParent();
-                currentThread.setContextClassLoader(standardClassLoader);
-                Object o;
-                try {
-                    o = new InitialContext().lookup(jndiName);
-                } finally {
-                    currentThread.setContextClassLoader(currentClassLoader);
-                }
+                Object o = ctx.lookup(jndiName);
                 resource.setLookedUp(true);
                 for (Iterator it = datasourceMappers.iterator(); it.hasNext();) {
                     DatasourceAccessor accessor = (DatasourceAccessor) it.next();
@@ -176,13 +171,14 @@ public class ResourceResolverBean implements ResourceResolver {
         }
     }
 
-    public synchronized boolean resetResource(final Context context, String resourceName) throws NamingException {
-        if (context != null) {
-            ContextBindings.bindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+    public synchronized boolean resetResource(final Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException {
+		if (context != null) {
+			((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).bindToContext(context);
         }
         try {
+			javax.naming.Context ctx = (context != null) ? new InitialContext() : getGlobalNamingContext();
             String jndiName = resolveJndiName(resourceName, (context == null));
-            Object o = new InitialContext().lookup(jndiName);
+            Object o = ctx.lookup(jndiName);
             try {
                 for (Iterator it = datasourceMappers.iterator(); it.hasNext();) {
                     DatasourceAccessor accessor = (DatasourceAccessor) it.next();
@@ -202,18 +198,19 @@ public class ResourceResolverBean implements ResourceResolver {
             }
         } finally {
             if (context != null) {
-                ContextBindings.unbindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+                ((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).unbindFromContext(context);
             }
         }
     }
 
-    public synchronized DataSource lookupDataSource(final Context context, String resourceName) throws NamingException {
+    public synchronized DataSource lookupDataSource(final Context context, String resourceName, ContainerWrapperBean containerWrapper) throws NamingException {
         if (context != null) {
-            ContextBindings.bindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+			((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).bindToContext(context);
         }
         try {
+			javax.naming.Context ctx = (context != null) ? new InitialContext() : getGlobalNamingContext();
             String jndiName = resolveJndiName(resourceName, (context == null));
-            Object o = new InitialContext().lookup(jndiName);
+            Object o = ctx.lookup(jndiName);
 
             if (o instanceof DataSource) {
                 return (DataSource) o;
@@ -222,7 +219,7 @@ public class ResourceResolverBean implements ResourceResolver {
             }
         } finally {
             if (context != null) {
-                ContextBindings.unbindClassLoader(context, null, Thread.currentThread().getContextClassLoader());
+                ((AbstractTomcatContainer) containerWrapper.getTomcatContainer()).unbindFromContext(context);
             }
         }
     }
@@ -274,5 +271,29 @@ public class ResourceResolverBean implements ResourceResolver {
             return null;
         }
     }
-
+	
+	/**
+     * Returns the Server's global naming context
+     *
+     * @return the global JNDI context
+     */
+	protected javax.naming.Context getGlobalNamingContext() {
+		
+		javax.naming.Context globalContext = null;
+		MBeanServer mBeanServer = getMBeanServer();
+		if (mBeanServer != null) {
+			try {
+				ObjectName name = new ObjectName("Catalina:type=Server");
+				Server server = (Server) mBeanServer.getAttribute(name, "managedResource");
+				//getGlobalNamingContext() was added to Server interface in Tomcat 7.0.11
+				if (server instanceof StandardServer) {
+					globalContext = ((StandardServer) server).getGlobalNamingContext();
+				}
+			} catch (Exception e) {
+				logger.error("There was an error getting globalContext through JMX server:", e);
+			}
+		}
+		
+		return globalContext;
+    }
 }

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/datasources/ResetDataSourceController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/datasources/ResetDataSourceController.java
@@ -52,7 +52,7 @@ public class ResetDataSourceController extends ContextHandlerController {
         if (resourceName != null && resourceName.length() > 0) {
             boolean reset = false;
             try {
-                reset = getContainerWrapper().getResourceResolver().resetResource(context, resourceName);
+                reset = getContainerWrapper().getResourceResolver().resetResource(context, resourceName, getContainerWrapper());
             } catch (NamingException e) {
                 request.setAttribute("errorMessage",
                         getMessageSourceAccessor().getMessage("probe.src.reset.datasource.notfound", new Object[]{resourceName}));

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/sql/ConnectionTestController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/sql/ConnectionTestController.java
@@ -41,7 +41,7 @@ public class ConnectionTestController extends ContextHandlerController {
         DataSource dataSource = null;
 
         try {
-            dataSource = getContainerWrapper().getResourceResolver().lookupDataSource(context, resourceName);
+            dataSource = getContainerWrapper().getResourceResolver().lookupDataSource(context, resourceName, getContainerWrapper());
         } catch (NamingException e) {
             request.setAttribute("errorMessage", getMessageSourceAccessor().getMessage("probe.src.dataSourceTest.resource.lookup.failure", new Object[]{resourceName}));
         }

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/sql/ExecuteSqlController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/sql/ExecuteSqlController.java
@@ -75,7 +75,7 @@ public class ExecuteSqlController extends ContextHandlerController {
         DataSource dataSource = null;
 
         try {
-            dataSource = getContainerWrapper().getResourceResolver().lookupDataSource(context, resourceName);
+            dataSource = getContainerWrapper().getResourceResolver().lookupDataSource(context, resourceName, getContainerWrapper());
         } catch (NamingException e) {
             request.setAttribute("errorMessage", getMessageSourceAccessor().getMessage("probe.src.dataSourceTest.resource.lookup.failure", new Object[]{resourceName}));
         }


### PR DESCRIPTION
Just put together all changes from pull request https://github.com/psi-probe/psi-probe/pull/465 into my master branch.

This fixes probe not listing global and application resources in Tomcat 8 while preserving Java 1.4 compatibility.

Tested on RHEL 7, Server JRE 1.8.0_40, Tomcat 8.0.21 and Probe 2.4.0-SNAPSHOT.