### PR TITLE
Remove IDE plugins - no longer necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,49 +453,8 @@
 						</dependency>
 					</dependencies>
 				</plugin>
-				<!-- IDE -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-eclipse-plugin</artifactId>
-					<version>2.7</version>
-					<configuration>
-						<downloadSources>true</downloadSources>
-						<downloadJavadocs>false</downloadJavadocs>
-						<wtpversion>2.0</wtpversion>
-						<wtpContextName>probe</wtpContextName>
-						<additionalBuildcommands>
-							<buildCommand>
-								<name>org.springframework.ide.eclipse.core.springbuilder</name>
-							</buildCommand>
-						</additionalBuildcommands>
-						<additionalProjectnatures>
-							<projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
-						</additionalProjectnatures>
-					</configuration>
-				  </plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-idea-plugin</artifactId>
-					<version>2.2</version>
-					<configuration>
-						<downloadSources>true</downloadSources>
-						<dependenciesAsLibraries>true</dependenciesAsLibraries>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<!-- begin IDE plugins -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-eclipse-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-idea-plugin</artifactId>
-			</plugin>
-			<!-- end IDE plugins -->
-		</plugins>
 	</build>
 	<profiles>
 		<profile>


### PR DESCRIPTION
IDE plugin for intellij is retired for a long time now.  Eclipse plugin
is going to be updated to maven 2.2.1 then it is likely headed to
retirement as well.  Both IDE's provide support beyond what these
plugins could provide natively.  Eclipse uses m2e.  Idea uses their own.