### PR TITLE
Updated log4j to avoid exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,26 +131,7 @@
 			<dependency>
 				<groupId>log4j</groupId>
 				<artifactId>log4j</artifactId>
-				<version>1.2.13</version>
-				<type>jar</type>
-				<exclusions>
-					<exclusion>
-						<groupId>javax.mail</groupId>
-						<artifactId>mail</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>javax.jms</groupId>
-						<artifactId>jms</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.sun.jdmk</groupId>
-						<artifactId>jmxtools</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.sun.jmx</groupId>
-						<artifactId>jmxri</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>1.2.17</version>
 			</dependency>
 			<dependency>
 				<groupId>com.oracle</groupId>


### PR DESCRIPTION
log4j 1.2.17 still targets java 1.4 making this a compliant update for psi-probe 2.4.