### PR TITLE
Use JTA 1.1 plus minor project changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
+  - openjdk7
   - openjdk6
-  

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@
 		mvn package
 
 	This will create a deployable file at `web/target/probe.war`.
+
+# User Group
+
+Please follow the user group on google groups: [psi-probe](http://groups.google.com/group/psi-probe/)

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,6 @@
 	</modules>
 	<repositories>
 		<repository>
-			<!-- Required for jta -->
-			<snapshots>
-				<enabled>false</enabled>
-				<updatePolicy>never</updatePolicy>
-			</snapshots>
-			<id>download.java.net</id>
-			<name>download.java.net</name>
-			<url>http://download.java.net/maven/2/</url>
-			<layout>default</layout>
-		</repository>
-		<repository>
 			<!-- Required for jmxri -->
 			<snapshots>
 				<enabled>false</enabled>
@@ -278,7 +267,7 @@
 			<dependency>
 				<groupId>javax.transaction</groupId>
 				<artifactId>jta</artifactId>
-				<version>1.0.1B</version>
+				<version>1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>opensymphony</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -45,16 +45,16 @@
 			<artifactId>tomcat80adaptor</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>servlet-api</artifactId>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>jsp-api</artifactId>
-				<scope>provided</scope>
-			</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jsp-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>


### PR DESCRIPTION
JTA 1.1 can be used directly from maven central and still targets java 1.4

Added openjdk7 to travis ci build
Added user group to README
Fixed formatting in POM from a prior change (excess tabs).