### PR TITLE
Junit 4.12

### DIFF
--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/FlapListenerTests.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/FlapListenerTests.java
@@ -10,14 +10,14 @@
  */
 package com.googlecode.psiprobe.beans.stats.listeners;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  *
  * @author Mark Lewis
  */
-public class FlapListenerTests extends TestCase {
+public class FlapListenerTests {
 
     private final int defaultThreshold = 10;
     private final int defaultInterval = 10;
@@ -34,13 +34,14 @@ public class FlapListenerTests extends TestCase {
         listener.reset();
         add(sce, defaultInterval);
     }
-    
+
     protected void add(StatsCollectionEvent sce, int quantity) {
         for (int i = 0; i < quantity; i++) {
             listener.statsCollected(sce);
         }
     }
-    
+
+    @Test
     public void testBelowThresholdNotFlapping() {
         listener.reset();
         listener.statsCollected(aboveThreshold);
@@ -48,6 +49,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isBelowThresholdNotFlapping());
     }
 
+    @Test
     public void testAboveThresholdNotFlapping() {
         listener.reset();
         listener.statsCollected(belowThreshold);
@@ -55,6 +57,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isAboveThresholdNotFlapping());
     }
 
+    @Test
     public void testStillBelowThreshold() {
         listener.reset();
         listener.statsCollected(belowThreshold);
@@ -64,6 +67,7 @@ public class FlapListenerTests extends TestCase {
         }
     }
 
+    @Test
     public void testStillAboveThreshold() {
         listener.reset();
         listener.statsCollected(aboveThreshold);
@@ -73,6 +77,7 @@ public class FlapListenerTests extends TestCase {
         }
     }
 
+    @Test
     public void testFlappingStarted() {
         fill(belowThreshold);
         listener.statsCollected(aboveThreshold);
@@ -81,6 +86,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isFlappingStarted());
     }
 
+    @Test
     public void testFlappingStarted2() {
         fill(aboveThreshold);
         listener.statsCollected(belowThreshold);
@@ -89,6 +95,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isFlappingStarted());
     }
 
+    @Test
     public void testBelowThresholdFlappingStoppedBelow() {
         fill(belowThreshold);
         listener.statsCollected(aboveThreshold);
@@ -99,6 +106,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isBelowThresholdFlappingStopped());
     }
 
+    @Test
     public void testBelowThresholdFlappingStoppedAbove() {
         fill(belowThreshold);
         listener.statsCollected(aboveThreshold);
@@ -109,6 +117,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isAboveThresholdFlappingStopped());
     }
 
+    @Test
     public void testAboveThresholdFlappingStoppedBelow() {
         fill(aboveThreshold);
         listener.statsCollected(belowThreshold);
@@ -119,6 +128,7 @@ public class FlapListenerTests extends TestCase {
         Assert.assertTrue(listener.isBelowThresholdFlappingStopped());
     }
 
+    @Test
     public void testAboveThresholdFlappingStoppedAbove() {
         fill(aboveThreshold);
         listener.statsCollected(belowThreshold);

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
@@ -10,14 +10,14 @@
  */
 package com.googlecode.psiprobe.beans.stats.listeners;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  *
  * @author Mark Lewis
  */
-public class ThresholdListenerTests extends TestCase {
+public class ThresholdListenerTests {
 
     private final long defaultThreshold = 10;
 
@@ -25,46 +25,52 @@ public class ThresholdListenerTests extends TestCase {
     private StatsCollectionEvent belowThreshold = new StatsCollectionEvent("test", 0, 0);
     private StatsCollectionEvent aboveThreshold = new StatsCollectionEvent("test", 0, 20);
 
+    @Test
     public void testFirstBelowThreshold() {
         listener.reset();
         listener.statsCollected(belowThreshold);
         Assert.assertTrue(listener.isRemainedBelowThreshold());
     }
-    
+
+    @Test
     public void testFirstAboveThreshold() {
         listener.reset();
         listener.statsCollected(aboveThreshold);
         Assert.assertTrue(listener.isCrossedAboveThreshold());
     }
-    
+
+    @Test
     public void testRemainBelowThreshold() {
         listener.reset();
         listener.statsCollected(belowThreshold);
         listener.statsCollected(belowThreshold);
         Assert.assertTrue(listener.isRemainedBelowThreshold());
     }
-    
+
+    @Test
     public void testRemainAboveThreshold() {
         listener.reset();
         listener.statsCollected(aboveThreshold);
         listener.statsCollected(aboveThreshold);
         Assert.assertTrue(listener.isRemainedAboveThreshold());
     }
-    
+
+    @Test
     public void testCrossedBelowThreshold() {
         listener.reset();
         listener.statsCollected(aboveThreshold);
         listener.statsCollected(belowThreshold);
         Assert.assertTrue(listener.isCrossedBelowThreshold());
     }
-    
+
+    @Test
     public void testCrossedAboveThreshold() {
         listener.reset();
         listener.statsCollected(belowThreshold);
         listener.statsCollected(aboveThreshold);
         Assert.assertTrue(listener.isCrossedAboveThreshold());
     }
-    
+
     public static class MockThresholdListener extends ThresholdListener {
 
         private final long threshold;

--- a/core/src/test/java/com/googlecode/psiprobe/tools/InstrumentsTests.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/InstrumentsTests.java
@@ -10,21 +10,24 @@
  */
 package com.googlecode.psiprobe.tools;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
  * @author Mark Lewis
  */
-public class InstrumentsTests extends TestCase {
+public class InstrumentsTests {
 
     private String sunArchDataModelProperty;
 
     /**
      * Forces the tests to run in 32-bit mode.
      */
-    protected void setUp() {
+    @Before
+    public void setUp() {
         this.sunArchDataModelProperty = System.getProperty("sun.arch.data.model");
         System.setProperty("sun.arch.data.model", "32");
     }
@@ -32,62 +35,72 @@ public class InstrumentsTests extends TestCase {
     /**
      * Undoes the changes made in {@link #setUp()}.
      */
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         System.setProperty("sun.arch.data.model", this.sunArchDataModelProperty);
     }
 
+    @Test
     public void testObject() {
         Object o = new Object();
         long objectSize = Instruments.sizeOf(o);
         Assert.assertEquals(Instruments.SIZE_OBJECT, objectSize);
     }
 
+    @Test
     public void testBoolean() {
         boolean b = false;
         long booleanSize = Instruments.sizeOf(new Boolean(b)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_BOOLEAN, booleanSize);
     }
 
+    @Test
     public void testByte() {
         byte b = 0x00;
         long byteSize = Instruments.sizeOf(new Byte(b)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_BYTE, byteSize);
     }
-    
+
+    @Test
     public void testChar() {
         char c = '\0';
         long charSize = Instruments.sizeOf(new Character(c)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_CHAR, charSize);
     }
 
+    @Test
     public void testShort() {
         short s = 0;
         long shortSize = Instruments.sizeOf(new Short(s)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_SHORT, shortSize);
     }
 
+    @Test
     public void testInt() {
         int i = 0;
         long intSize = Instruments.sizeOf(new Integer(i)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_INT, intSize);
     }
 
+    @Test
     public void testLong() {
         long l = 0;
         long longSize = Instruments.sizeOf(new Long(l)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_LONG, longSize);
     }
 
+    @Test
     public void testFloat() {
         float f = 0.0f;
         long floatSize = Instruments.sizeOf(new Float(f)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_FLOAT, floatSize);
     }
 
+    @Test
     public void testDouble() {
         double d = 0.0;
         long doubleSize = Instruments.sizeOf(new Double(d)) - Instruments.SIZE_OBJECT;
         Assert.assertEquals(Instruments.SIZE_DOUBLE, doubleSize);
     }
-    
+
 }

--- a/core/src/test/java/com/googlecode/psiprobe/tools/SizeExpressionTests.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/SizeExpressionTests.java
@@ -11,26 +11,32 @@
 package com.googlecode.psiprobe.tools;
 
 import java.util.Locale;
-import junit.framework.Assert;
-import junit.framework.TestCase;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
  * @author Mark Lewis
  */
-public class SizeExpressionTests extends TestCase {
-    
+public class SizeExpressionTests {
+
     private Locale defaultLocale;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         this.defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         Locale.setDefault(defaultLocale);
     }
-    
+
+    @Test
     public void testFormatNoDecimalBase2() {
         Assert.assertEquals("1 B", SizeExpression.format(1, 0, true));
         Assert.assertEquals("10 B", SizeExpression.format(10, 0, true));
@@ -41,7 +47,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("10 KB", SizeExpression.format(10240, 0, true));
         Assert.assertEquals("10 KB", SizeExpression.format(10250, 0, true));
     }
-    
+
+    @Test
     public void testFormatNoDecimalBase10() {
         Assert.assertEquals("1", SizeExpression.format(1, 0, false));
         Assert.assertEquals("10", SizeExpression.format(10, 0, false));
@@ -52,7 +59,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("10K", SizeExpression.format(10240, 0, false));
         Assert.assertEquals("10K", SizeExpression.format(10250, 0, false));
     }
-    
+
+    @Test
     public void testFormatOneDecimalBase2() {
         Assert.assertEquals("1 B", SizeExpression.format(1, 1, true));
         Assert.assertEquals("10 B", SizeExpression.format(10, 1, true));
@@ -63,7 +71,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("10.0 KB", SizeExpression.format(10240, 1, true));
         Assert.assertEquals("10.0 KB", SizeExpression.format(10250, 1, true));
     }
-    
+
+    @Test
     public void testFormatOneDecimalBase10() {
         Assert.assertEquals("1", SizeExpression.format(1, 1, false));
         Assert.assertEquals("10", SizeExpression.format(10, 1, false));
@@ -74,7 +83,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("10.2K", SizeExpression.format(10240, 1, false));
         Assert.assertEquals("10.3K", SizeExpression.format(10250, 1, false));
     }
-    
+
+    @Test
     public void testFormatAllPrefixesBase2() {
         Assert.assertEquals("1 B", SizeExpression.format(1, 0, true));
         Assert.assertEquals("1 KB", SizeExpression.format(1024, 0, true));
@@ -83,7 +93,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("1 TB", SizeExpression.format(1099511627776L, 0, true));
         Assert.assertEquals("1 PB", SizeExpression.format(1125899906842624L, 0, true));
     }
-    
+
+    @Test
     public void testFormatAllPrefixesBase10() {
         Assert.assertEquals("1", SizeExpression.format(1, 0, false));
         Assert.assertEquals("1K", SizeExpression.format(1000, 0, false));
@@ -92,7 +103,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals("1T", SizeExpression.format(1000000000000L, 0, false));
         Assert.assertEquals("1P", SizeExpression.format(1000000000000000L, 0, false));
     }
-    
+
+    @Test
     public void testParseWithUnit() {
         Assert.assertEquals(1, SizeExpression.parse("1B"));
         Assert.assertEquals(10, SizeExpression.parse("10B"));
@@ -107,7 +119,8 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals(1099511627776L, SizeExpression.parse("1TB"));
         Assert.assertEquals(1125899906842624L, SizeExpression.parse("1PB"));
     }
-    
+
+    @Test
     public void testParseWithoutUnit() {
         Assert.assertEquals(1, SizeExpression.parse("1"));
         Assert.assertEquals(10, SizeExpression.parse("10"));
@@ -122,5 +135,5 @@ public class SizeExpressionTests extends TestCase {
         Assert.assertEquals(1000000000000L, SizeExpression.parse("1T"));
         Assert.assertEquals(1000000000000000L, SizeExpression.parse("1P"));
     }
-    
+
 }

--- a/core/src/test/java/com/googlecode/psiprobe/tools/WhoisTests.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/WhoisTests.java
@@ -11,9 +11,13 @@
 package com.googlecode.psiprobe.tools;
 
 import com.googlecode.psiprobe.tools.Whois.Response;
+
 import java.io.IOException;
 import java.net.InetAddress;
-import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.Assert;
+
 import junit.framework.TestCase;
 
 /**
@@ -22,6 +26,7 @@ import junit.framework.TestCase;
  */
 public class WhoisTests extends TestCase {
 
+    @Test
     public void testLocalhost() throws IOException {
         int a = 127;
         int b = 0;
@@ -35,7 +40,8 @@ public class WhoisTests extends TestCase {
         //System.out.println(InetAddress.getByName(dotted).getHostName());
         //System.out.println(InetAddress.getByAddress(bytes).getHostName());
     }
-    
+
+    @Test
     public void testGoogle() throws IOException {
         int a = 74;
         int b = 125;
@@ -49,5 +55,5 @@ public class WhoisTests extends TestCase {
         //System.out.println(InetAddress.getByName(dotted).getHostName());
         //System.out.println(InetAddress.getByAddress(bytes).getHostName());
     }
-    
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>3.8.1</version>
+				<version>4.12</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
 			<layout>default</layout>
 		</repository>
 	</repositories>
+	<properties>
+		<maven.compiler.source>1.4</maven.compiler.source>
+		<maven.compiler.target>1.4</maven.compiler.target>
+		<maven.compiler.testSource>1.5</maven.compiler.testSource>
+		<maven.compiler.testTarget>1.5</maven.compiler.testTarget>
+	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -368,10 +374,8 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.0.2</version>
+					<version>3.2</version>
 					<configuration>
-						<source>1.4</source>
-						<target>1.4</target>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
Per #453, this library is using maven 3.  Therefore, it can use the latest compiler.  Additionally, this opens the door to continue compiling source/target for 1.4 java while treating test as source/target 1.5.  This allows for the library to be upgraded to junit 4.12 through a bit of maven magic.  This does not affect the outcome of the build itself and still is compliant for java 1.4.  All JVMs used to build are 1.6 and above which means this is suitable for inclusion into the build process even with psi-probe 2.4.0.