### PR TITLE
TomcatSlf4jLogback Support

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/controllers/logs/ChangeLogLevelController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/logs/ChangeLogLevelController.java
@@ -14,9 +14,13 @@ import com.googlecode.psiprobe.tools.logging.LogDestination;
 import com.googlecode.psiprobe.tools.logging.jdk.Jdk14HandlerAccessor;
 import com.googlecode.psiprobe.tools.logging.log4j.Log4JAppenderAccessor;
 import com.googlecode.psiprobe.tools.logging.logback.LogbackAppenderAccessor;
+import com.googlecode.psiprobe.tools.logging.tomcatSlf4jLogback.TomcatSlf4jLogbackAppenderAccessor;
+
 import java.util.Arrays;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -37,6 +41,9 @@ public class ChangeLogLevelController extends LogHandlerController {
                 accessor.getLoggerAccessor().setLevel(level);
             } else if (logDest instanceof LogbackAppenderAccessor) {
                 LogbackAppenderAccessor accessor = (LogbackAppenderAccessor) logDest;
+                accessor.getLoggerAccessor().setLevel(level);
+            } else if (logDest instanceof TomcatSlf4jLogbackAppenderAccessor) {
+                TomcatSlf4jLogbackAppenderAccessor accessor = (TomcatSlf4jLogbackAppenderAccessor) logDest;
                 accessor.getLoggerAccessor().setLevel(level);
             }
         }

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackAppenderAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackAppenderAccessor.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the GPL License.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.googlecode.psiprobe.tools.logging.tomcatSlf4jLogback;
+
+import com.googlecode.psiprobe.tools.logging.AbstractLogDestination;
+import java.io.File;
+
+/**
+ * A wrapper for a TomcatSlf4jLogback appender for a specific logger.
+ * 
+ * @author Jeremy Landis
+ */
+public class TomcatSlf4jLogbackAppenderAccessor extends AbstractLogDestination {
+
+    private TomcatSlf4jLogbackLoggerAccessor loggerAccessor;
+
+    public TomcatSlf4jLogbackLoggerAccessor getLoggerAccessor() {
+        return loggerAccessor;
+    }
+
+    public void setLoggerAccessor(TomcatSlf4jLogbackLoggerAccessor loggerAccessor) {
+        this.loggerAccessor = loggerAccessor;
+    }
+
+    public boolean isContext() {
+        return getLoggerAccessor().isContext();
+    }
+
+    public boolean isRoot() {
+        return getLoggerAccessor().isRoot();
+    }
+
+    public String getName() {
+        return getLoggerAccessor().getName();
+    }
+
+    /**
+     * Returns the log type, to distinguish tomcatSlf4jLogback appenders from other types
+     * like log4j appenders or jdk handlers.
+     * 
+     * @return the log type
+     */
+    public String getLogType() {
+        return "tomcatSlf4jLogback";
+    }
+
+    /**
+     * Returns the name of this appender.
+     * 
+     * @return the name of this appender.
+     */
+    public String getIndex() {
+        return (String) getProperty(getTarget(), "name", null);
+    }
+
+    /**
+     * Returns the file that this appender writes to by accessing the
+     * {@code file} bean property of the appender.
+     * 
+     * <p>
+     * If no such property exists, we assume the appender to write to stdout or
+     * stderr so the output will be contained in catalina.out.
+     * <p>
+     * 
+     * @return the file this appender writes to
+     */
+    public File getFile() {
+        String fileName = (String) getProperty(getTarget(), "file", null);
+        return fileName != null ? new File(fileName) : getStdoutFile();
+    }
+
+    /**
+     * Gets the level of the associated logger.
+     * 
+     * @return the logger's level
+     */
+    public String getLevel() {
+        return getLoggerAccessor().getLevel();
+    }
+
+    /**
+     * Returns the valid log level names.
+     * 
+     * <p>
+     * Note that Logback has no FATAL level.
+     * </p>
+     * 
+     * @return the valid log level names
+     */
+    public String[] getValidLevels() {
+        return new String[] {"OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL"};
+    }
+
+}

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackFactoryAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackFactoryAccessor.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the GPL License.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.googlecode.psiprobe.tools.logging.tomcatSlf4jLogback;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.beanutils.MethodUtils;
+
+import com.googlecode.psiprobe.tools.logging.DefaultAccessor;
+
+/**
+ * Wraps a TomcatSlf4jLogback logger factory from a given web application class loader.
+ * 
+ * <p>
+ * All TomcatSlf4jLogback classes are loaded via the given class loader and not via psi-probe's own
+ * class loader. For this reasons, all methods on TomcatSlf4jLogback objects are invoked via reflection.
+ * </p>
+ * <p>
+ * This way, we can even handle different versions of TomcatSlf4jLogback embedded in different WARs.
+ * </p>
+ * 
+ * @author Jeremy Landis
+ */
+public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
+
+    /**
+     * Attempts to initialize a TomcatSlf4jLogback logger factory via the given class loader.
+     *  
+     * @param cl the ClassLoader to use when fetching the factory
+     */
+    public TomcatSlf4jLogbackFactoryAccessor(ClassLoader cl) throws ClassNotFoundException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        // Get the singleton SLF4J binding, which may or may not be Logback, depending on the binding.
+        Class clazz = cl.loadClass("org.apache.juli.logging.org.slf4j.impl.StaticLoggerBinder");
+        Method m1 = MethodUtils.getAccessibleMethod(clazz, "getSingleton", new Class[]{});
+        Object singleton = m1.invoke(null, null);
+        Method m = MethodUtils.getAccessibleMethod(clazz, "getLoggerFactory", new Class[]{});
+        Object loggerFactory = m.invoke(singleton, null);
+
+        // Check if the binding is indeed Logback
+        Class loggerFactoryClass = cl.loadClass("org.apache.juli.logging.ch.qos.logback.classic.LoggerContext");
+        if (!loggerFactoryClass.isInstance(loggerFactory)) {
+            throw new RuntimeException("The singleton SLF4J binding was not Logback");
+        }
+        setTarget(loggerFactory);
+    }
+
+    /**
+     * Returns the TomcatSlf4jLogback root logger.
+     * 
+     * @return the root logger
+     */
+    public TomcatSlf4jLogbackLoggerAccessor getRootLogger() {
+        // TomcatSlf4jLogback has no dedicated getRootLogger() method, so we simply access the root logger
+        // by its well-defined name.
+        return getLogger("ROOT");
+    }
+
+    /**
+     * Returns the TomcatSlf4jLogback logger with a given name.
+     * 
+     * @return the Logger with the given name
+     */
+    public TomcatSlf4jLogbackLoggerAccessor getLogger(String name) {
+        try {
+            Class clazz = getTarget().getClass();
+            Method m = MethodUtils.getAccessibleMethod(clazz, "getLogger", new Class[] {String.class});
+            Object logger = m.invoke(getTarget(), new Object[] {name});
+            if (logger == null) {
+                throw new NullPointerException(getTarget() + ".getLogger(\"" + name + "\") returned null");
+            }
+            TomcatSlf4jLogbackLoggerAccessor accessor = new TomcatSlf4jLogbackLoggerAccessor();
+            accessor.setTarget(logger);
+            accessor.setApplication(getApplication());
+            return accessor;
+
+        } catch (Exception e) {
+            log.error(getTarget() + ".getLogger(\"" + name + "\") failed", e);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a list of wrappers for all TomcatSlf4jLogback appenders that have an
+     * associated logger.
+     * 
+     * @return a list of {@link TomcatSlf4jLogbackAppenderAccessor}s representing all
+     *         appenders that are in use
+     */
+    public List getAppenders() {
+        List appenders = new ArrayList();
+        try {
+            Class clazz = getTarget().getClass();
+            Method m = MethodUtils.getAccessibleMethod(clazz, "getLoggerList", new Class[]{});
+            List loggers = (List) m.invoke(getTarget(), null);
+            Iterator it = loggers.iterator();
+            while (it.hasNext()) {
+                TomcatSlf4jLogbackLoggerAccessor accessor = new TomcatSlf4jLogbackLoggerAccessor();
+                accessor.setTarget(it.next());
+                accessor.setApplication(getApplication());
+
+                appenders.addAll(accessor.getAppenders());
+            }
+        } catch (Exception e) {
+            log.error(getTarget() + ".getLoggerList() failed", e);
+        }
+        return appenders;
+    }
+
+}

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackLoggerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/tomcatSlf4jLogback/TomcatSlf4jLogbackLoggerAccessor.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the GPL License.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.googlecode.psiprobe.tools.logging.tomcatSlf4jLogback;
+
+import com.googlecode.psiprobe.tools.logging.DefaultAccessor;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.beanutils.MethodUtils;
+
+/**
+ * A wrapper for a TomcatSlf4jLogback logger.
+ * 
+ * @author Jeremy Landis
+ */
+public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
+
+    /**
+     * Returns all appenders of this logger.
+     * 
+     * @return a list of {@link TomcatSlf4jLogbackAppenderAccessor}s
+     */
+    public List getAppenders() {
+        List appenders = new ArrayList();
+        try {
+            Iterator it =  (Iterator) MethodUtils.invokeMethod(getTarget(), "iteratorForAppenders", null);
+            while (it.hasNext()) {
+                Object appender = it.next();
+                List siftedAppenders = getSiftedAppenders(appender);
+                if (siftedAppenders != null) {
+                    for (int i = 0; i < siftedAppenders.size(); i++) {
+                        Object siftedAppender = siftedAppenders.get(i);
+                        wrapAndAddAppender(siftedAppender, appenders);
+                    }
+                } else {
+                    wrapAndAddAppender(appender, appenders);
+                }
+            }
+        } catch (Exception e) {
+            log.error(getTarget().getClass().getName() + "#getAppenders() failed", e);
+        }
+        return appenders;
+    }
+
+    /**
+     * Returns the appender of this logger with the given name.
+     * 
+     * @param name the name of the appender to return
+     * @return the appender with the given name, or null if no such
+     *         appender exists for this logger
+     */
+    public TomcatSlf4jLogbackAppenderAccessor getAppender(String name) {
+        try {
+            Object appender = MethodUtils.invokeMethod(getTarget(), "getAppender", name);
+            if (appender == null) {
+                List appenders = getAppenders();
+                for (int i = 0; i < appenders.size(); i++) {
+                    TomcatSlf4jLogbackAppenderAccessor wrappedAppender = (TomcatSlf4jLogbackAppenderAccessor) appenders.get(i);
+                    if (wrappedAppender.getIndex().equals(name)) {
+                        return wrappedAppender;
+                    }
+                }
+            }
+            return wrapAppender(appender);
+        } catch (Exception e) {
+            log.error(getTarget().getClass().getName() + "#getAppender() failed", e);
+        }
+        return null;
+    }
+
+    public boolean isContext() {
+        return false;
+    }
+
+    public boolean isRoot() {
+        return "ROOT".equals(getName());
+    }
+
+    public String getName() {
+        return (String) getProperty(getTarget(), "name", null);
+    }
+
+    /**
+     * Gets the log level of this logger.
+     * 
+     * @return the level of this logger
+     */
+    public String getLevel() {
+        try {
+            Object level = MethodUtils.invokeMethod(getTarget(), "getLevel", null);
+            return (String) MethodUtils.invokeMethod(level, "toString", null);
+        } catch (Exception e) {
+            log.error(getTarget().getClass().getName() + "#getLevel() failed", e);
+        }
+        return null;
+    }
+
+    /**
+     * Sets the log level of this logger.
+     * 
+     * @param newLevelStr the name of the new level
+     */
+    public void setLevel(String newLevelStr) {
+        try {
+            Object level = MethodUtils.invokeMethod(getTarget(), "getLevel", null);
+            Object newLevel = MethodUtils.invokeMethod(level, "toLevel", newLevelStr);
+            MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
+        } catch (Exception e) {
+            log.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+        }
+    }
+
+    private List getSiftedAppenders(Object appender) throws Exception {
+        if ("org.apache.juli.logging.ch.qos.logback.classic.sift.SiftingAppender".equals(appender.getClass().getName())) {
+            Object tracker = MethodUtils.invokeMethod(appender, "getAppenderTracker", null);
+            if (tracker != null) {
+                return (List) MethodUtils.invokeMethod(tracker, "valueList", null);
+            } else {
+                return new ArrayList();
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private void wrapAndAddAppender(Object appender, List appenders) {
+        TomcatSlf4jLogbackAppenderAccessor appenderAccessor = wrapAppender(appender);
+        if (appenderAccessor != null) {
+            appenders.add(appenderAccessor);
+        }
+    }
+
+    private TomcatSlf4jLogbackAppenderAccessor wrapAppender(Object appender) {
+        try {
+            if (appender == null) {
+                throw new IllegalArgumentException("appender is null");
+            }
+            TomcatSlf4jLogbackAppenderAccessor appenderAccessor = new TomcatSlf4jLogbackAppenderAccessor();
+            appenderAccessor.setTarget(appender);
+            appenderAccessor.setLoggerAccessor(this);
+            appenderAccessor.setApplication(getApplication());
+            return appenderAccessor;
+        } catch (Exception e) {
+            log.error("Could not wrap appender: " + appender, e);
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
Tomcat-slf4j-logback project replaces tomcat juli with slf4j/logback. See [here](https://github.com/grgrzybek/tomcat-slf4j-logback)

This results in inability for psi-probe to see those logs.  This change
treats the logs similar to logback and thus makes them available and
accessible.