### PR TITLE
Align tomcat poms 5, 6, 7, 8

### DIFF
--- a/tomcat55adaptor/pom.xml
+++ b/tomcat55adaptor/pom.xml
@@ -22,23 +22,25 @@
 	<properties>
 		<git.relative.path>../</git.relative.path>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
+				<artifactId>core</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>tomcat</groupId>
+				<artifactId>servlet-api</artifactId>
+				<version>5.5.23</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>core</artifactId>
-			<version>${project.version}</version>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>tomcat</groupId>
-			<artifactId>naming-factory</artifactId>
-			<version>5.5.23</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>tomcat</groupId>
@@ -51,6 +53,12 @@
 			<artifactId>naming-resources</artifactId>
 			<version>5.5.23</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-logging-api</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>tomcat</groupId>
@@ -62,6 +70,17 @@
 			<groupId>tomcat</groupId>
 			<artifactId>tomcat-util</artifactId>
 			<version>5.5.23</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-logging-api</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>tomcat</groupId>
+			<artifactId>servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/tomcat60adaptor/pom.xml
+++ b/tomcat60adaptor/pom.xml
@@ -36,29 +36,18 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>servlet-api</artifactId>
-				<version>2.5</version>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>catalina</artifactId>
-				<version>6.0.43</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>servlet-api</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>6.0.44</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>jasper</artifactId>
-				<version>6.0.43</version>
+				<version>6.0.44</version>
 				<exclusions>
 					<exclusion>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>servlet-api</artifactId>
+						<artifactId>ecj</artifactId>
+						<groupId>org.eclipse.jdt.core.compiler</groupId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -71,16 +60,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-modeler</groupId>
-			<artifactId>commons-modeler</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>catalina</artifactId>
 			<scope>provided</scope>
@@ -89,12 +68,11 @@
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>jasper</artifactId>
 			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>ecj</artifactId>
-					<groupId>org.eclipse.jdt.core.compiler</groupId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-modeler</groupId>
+			<artifactId>commons-modeler</artifactId>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/tomcat70adaptor/pom.xml
+++ b/tomcat70adaptor/pom.xml
@@ -38,12 +38,12 @@
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-catalina</artifactId>
-				<version>7.0.61</version>
+				<version>7.0.62</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-jasper</artifactId>
-				<version>7.0.61</version>
+				<version>7.0.62</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>ecj</artifactId>

--- a/tomcat80adaptor/pom.xml
+++ b/tomcat80adaptor/pom.xml
@@ -38,12 +38,12 @@
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-catalina</artifactId>
-				<version>8.0.21</version>
+				<version>8.0.23</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-jasper</artifactId>
-				<version>8.0.21</version>
+				<version>8.0.23</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>ecj</artifactId>


### PR DESCRIPTION
This has been sitting a bit on my machine...

Align poms for tomcat so they are fairly close to being the same.  Update to latest tomcat 7 and just one behind on tomcat 8.  Effectively not much going on here.

On jsp pages, language tag is obsolete and otherwise ignored.  Cleared all the warnings.  Again effectively not much going on here.