### PR TITLE
- Fixes #529  dependency scope optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 
 # Project
 *.log
+psi-probe.iws
+psi-probe.ipr

--- a/tomcat55adaptor/pom.xml
+++ b/tomcat55adaptor/pom.xml
@@ -33,6 +33,7 @@
 				<groupId>tomcat</groupId>
 				<artifactId>servlet-api</artifactId>
 				<version>5.5.23</version>
+				<scope>provided</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/tomcat60adaptor/pom.xml
+++ b/tomcat60adaptor/pom.xml
@@ -39,11 +39,13 @@
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>catalina</artifactId>
 				<version>6.0.44</version>
+				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>jasper</artifactId>
 				<version>6.0.44</version>
+				<scope>provided</scope>
 				<exclusions>
 					<exclusion>
 						<artifactId>ecj</artifactId>

--- a/tomcat70adaptor/pom.xml
+++ b/tomcat70adaptor/pom.xml
@@ -44,6 +44,7 @@
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-jasper</artifactId>
 				<version>7.0.62</version>
+				<scope>provided</scope>
 				<exclusions>
 					<exclusion>
 						<artifactId>ecj</artifactId>

--- a/tomcat80adaptor/pom.xml
+++ b/tomcat80adaptor/pom.xml
@@ -39,11 +39,13 @@
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-catalina</artifactId>
 				<version>8.0.23</version>
+				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>
 				<artifactId>tomcat-jasper</artifactId>
 				<version>8.0.23</version>
+				<scope>provided</scope>
 				<exclusions>
 					<exclusion>
 						<artifactId>ecj</artifactId>


### PR DESCRIPTION
Fix scope of artifacts to be able to run the project in Intellij IDEA.

While setup project in Intellij IDEA 14, I noticed that you are unable to run the project in Tomcat.
Reason for this is the clash of libraries. All Tomcat specific artifacts must have scope provided, otherwise they are deployed.

