### PR TITLE
Fix listing global/application datasources on Tomcat 6 and 7

### DIFF
--- a/tomcat60adaptor/src/main/java/com/googlecode/psiprobe/Tomcat60ContainerAdaptor.java
+++ b/tomcat60adaptor/src/main/java/com/googlecode/psiprobe/Tomcat60ContainerAdaptor.java
@@ -28,6 +28,7 @@ import org.apache.catalina.deploy.FilterDef;
 import org.apache.catalina.deploy.FilterMap;
 import org.apache.catalina.deploy.NamingResources;
 import org.apache.commons.modeler.Registry;
+import org.apache.naming.ContextBindings;
 import org.apache.naming.resources.Resource;
 import org.apache.naming.resources.ResourceAttributes;
 
@@ -401,4 +402,14 @@ public class Tomcat60ContainerAdaptor extends AbstractTomcatContainer {
     return result;
   }
 
+  @Override
+  public void bindToContext(Context context) throws NamingException {
+    ContextBindings.bindClassLoader(context, context,
+        Thread.currentThread().getContextClassLoader());
+  }
+
+  public void unbindFromContext(Context context) throws NamingException {
+    ContextBindings.unbindClassLoader(context, context,
+        Thread.currentThread().getContextClassLoader());
+  }
 }

--- a/tomcat70adaptor/src/main/java/com/googlecode/psiprobe/Tomcat70ContainerAdaptor.java
+++ b/tomcat70adaptor/src/main/java/com/googlecode/psiprobe/Tomcat70ContainerAdaptor.java
@@ -33,6 +33,7 @@ import org.apache.jasper.JspCompilationContext;
 import org.apache.jasper.Options;
 import org.apache.jasper.compiler.JspRuntimeContext;
 import org.apache.jasper.servlet.JspServletWrapper;
+import org.apache.naming.ContextBindings;
 import org.apache.naming.resources.Resource;
 import org.apache.naming.resources.ResourceAttributes;
 
@@ -436,4 +437,14 @@ public class Tomcat70ContainerAdaptor extends AbstractTomcatContainer {
     return result;
   }
 
+  @Override
+  public void bindToContext(Context context) throws NamingException {
+    ContextBindings.bindClassLoader(context, context,
+        Thread.currentThread().getContextClassLoader());
+  }
+
+  public void unbindFromContext(Context context) throws NamingException {
+    ContextBindings.unbindClassLoader(context, context,
+        Thread.currentThread().getContextClassLoader());
+  }
 }


### PR DESCRIPTION
Fixes #531.

The `AbstractTomcatContainer.bindToContext` and `unbindToContext` implementation doesn't work because it pass null to token.

I override both methods on Tomcat60ContainerAdaptor and Tomcat70ContainerAdaptor to pass the apropriate expected value.

I have test this on Tomcat 6 (Java 5 and 6) and on Tomcat 7 (Java 6), but I believe it will work on Java 7 and 8. I will test it on the next days.