### PR TITLE
Fix listing global/application datasources on Tomcat8

### DIFF
--- a/tomcat80adaptor/pom.xml
+++ b/tomcat80adaptor/pom.xml
@@ -55,6 +55,12 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-dbcp</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-modeler</groupId>
 			<artifactId>commons-modeler</artifactId>
 			<scope>compile</scope>

--- a/tomcat80adaptor/src/main/java/com/googlecode/psiprobe/beans/Tomcat8DbcpDatasourceAccessor.java
+++ b/tomcat80adaptor/src/main/java/com/googlecode/psiprobe/beans/Tomcat8DbcpDatasourceAccessor.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * 
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package com.googlecode.psiprobe.beans;
+
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+
+import com.googlecode.psiprobe.beans.DatasourceAccessor;
+import com.googlecode.psiprobe.model.DataSourceInfo;
+
+/**
+ * 
+ * @author Vlad Ilyushchenko
+ * @author Mark Lewis
+ * @author Diogo Sant'Ana <diogosantana@gmail.com>
+ */
+public class Tomcat8DbcpDatasourceAccessor implements DatasourceAccessor {
+
+  public DataSourceInfo getInfo(Object resource) throws Exception {
+    DataSourceInfo dataSourceInfo = null;
+    if (canMap(resource)) {
+      BasicDataSource source = (BasicDataSource) resource;
+      dataSourceInfo = new DataSourceInfo();
+      dataSourceInfo.setBusyConnections(source.getNumActive());
+      dataSourceInfo.setEstablishedConnections(source.getNumIdle() + source.getNumActive());
+      dataSourceInfo.setMaxConnections(source.getMaxTotal());
+      dataSourceInfo.setJdbcURL(source.getUrl());
+      dataSourceInfo.setUsername(source.getUsername());
+      dataSourceInfo.setResettable(false);
+      dataSourceInfo.setType("tomcat-dbcp2");
+    }
+    return dataSourceInfo;
+  }
+
+  public boolean reset(Object resource) throws Exception {
+    return false;
+  }
+
+  public boolean canMap(Object resource) {
+    return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource".equals(resource.getClass().getName())
+        && resource instanceof BasicDataSource;
+  }
+
+}

--- a/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
@@ -40,6 +40,7 @@
 				<bean class="com.googlecode.psiprobe.beans.C3P0DatasourceAccessor"/>
 				<bean class="com.googlecode.psiprobe.beans.DbcpDatasourceAccessor"/>
 				<bean class="com.googlecode.psiprobe.beans.TomcatDbcpDatasourceAccessor"/>
+				<bean class="com.googlecode.psiprobe.beans.Tomcat8DbcpDatasourceAccessor"/>
 				<bean class="com.googlecode.psiprobe.beans.TomcatJdbcPoolDatasourceAccessor"/>
 				<bean class="com.googlecode.psiprobe.beans.OracleDatasourceAccessor"/>
 				<bean class="com.googlecode.psiprobe.beans.OracleUcpDatasourceAssessor"/>


### PR DESCRIPTION
Fixes #534 Psi probe not listing global/application datasources on Tomcat 8.