### PR TITLE
Adding the support for Pivotal tc servers. 

### DIFF
--- a/tomcat70adaptor/src/main/java/com/googlecode/psiprobe/Tomcat70ContainerAdaptor.java
+++ b/tomcat70adaptor/src/main/java/com/googlecode/psiprobe/Tomcat70ContainerAdaptor.java
@@ -95,6 +95,7 @@ public class Tomcat70ContainerAdaptor extends AbstractTomcatContainer {
       canBind |= binding.startsWith("NonStop(tm) Servlets For JavaServer Pages(tm) v7.0");
       canBind |= (binding.startsWith("SpringSource tc") && binding.contains("/7.0"));
       canBind |= (binding.startsWith("VMware vFabric tc") && binding.contains("/7.0"));
+      canBind |= (binding.startsWith("Pivotal tc") && binding.contains("/7.0"));
     }
     return canBind;
   }

--- a/tomcat80adaptor/src/main/java/com/googlecode/psiprobe/Tomcat80ContainerAdaptor.java
+++ b/tomcat80adaptor/src/main/java/com/googlecode/psiprobe/Tomcat80ContainerAdaptor.java
@@ -90,6 +90,7 @@ public class Tomcat80ContainerAdaptor extends AbstractTomcatContainer {
     if (binding != null) {
       canBind |= binding.startsWith("Apache Tomcat/8.0");
       canBind |= binding.startsWith("Apache Tomcat (TomEE)/8.0");
+      canBind |= (binding.startsWith("Pivotal tc") && binding.contains("/7.0"));
     }
     return canBind;
   }


### PR DESCRIPTION
This was done to enable the tab Applications, System Information etc to show up, as the probe was
unable to identify the Pivotal server.