### PR TITLE
[#379 Fix] Update to latest quartz 2.2.2 with spring and slf4j adjust…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -191,7 +191,7 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>opensymphony</groupId>
+			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
 			<scope>compile</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,12 @@
 				<groupId>org.quartz-scheduler</groupId>
 				<artifactId>quartz</artifactId>
 				<version>2.2.2</version>
+				<exclusions>
+					<exclusion>
+						<groupId>c3p0</groupId>
+						<artifactId>c3p0</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>opensymphony</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,20 @@
 						<groupId>com.lowagie</groupId>
 						<artifactId>itext</artifactId>
 					</exclusion>
+					<exclusion>
+						<artifactId>jcl104-over-slf4j</artifactId>
+						<groupId>org.slf4j</groupId>
+					</exclusion>
+					<exclusion>
+						<artifactId>slf4j-log4j12</artifactId>
+						<groupId>org.slf4j</groupId>
+					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>1.7.12</version>
 			</dependency>
 			<dependency>
 				<groupId>jaxen</groupId>
@@ -290,9 +303,9 @@
 				<version>1.1</version>
 			</dependency>
 			<dependency>
-				<groupId>opensymphony</groupId>
+				<groupId>org.quartz-scheduler</groupId>
 				<artifactId>quartz</artifactId>
-				<version>1.6.3</version>
+				<version>2.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>opensymphony</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -64,6 +64,10 @@
 			<artifactId>displaytag</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 			<scope>runtime</scope>

--- a/web/src/main/webapp/WEB-INF/spring-probe-stats.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-stats.xml
@@ -365,7 +365,7 @@
 		<property name="concurrent" value="false"/>
 	</bean>
 
-	<bean id="connectorStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="connectorStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="connectorStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -381,7 +381,7 @@
 		</property>
 	</bean>
 
-	<bean id="clusterStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="clusterStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="clusterStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -397,7 +397,7 @@
 		</property>
 	</bean>
 
-	<bean id="memoryStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="memoryStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="memoryStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -413,7 +413,7 @@
 		</property>
 	</bean>
 
-	<bean id="runtimeStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="runtimeStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="runtimeStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -429,7 +429,7 @@
 		</property>
 	</bean>
 
-	<bean id="appStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="appStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="appStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -445,7 +445,7 @@
 		</property>
 	</bean>
 
-	<bean id="datasourceStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="datasourceStatsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="datasourceStatsJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
@@ -461,7 +461,7 @@
 		</property>
 	</bean>
 
-	<bean id="statsSerializerTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="statsSerializerTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="statsSerializerJobDetail"/>
 		<property name="cronExpression">
 			<bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">


### PR DESCRIPTION
…ments.  Quartz 2 uses slf4j so reworked it a bit so logging from that library will go to log4j as intended in the current psi-probe setup.