### PR TITLE
Spring4 - partial

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
@@ -19,6 +19,7 @@ import com.googlecode.psiprobe.tools.ApplicationUtils;
 import org.apache.catalina.Context;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.ServletContextAware;
 
 import javax.servlet.ServletContext;
@@ -39,6 +40,7 @@ public class AppStatsCollectorBean extends AbstractStatsCollectorBean implements
   private ContainerWrapperBean containerWrapper;
   
   /** The servlet context. */
+  @Autowired
   private ServletContext servletContext;
   
   /** The self ignored. */

--- a/pom.xml
+++ b/pom.xml
@@ -256,27 +256,27 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-beans</artifactId>
-				<version>3.2.14.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-context</artifactId>
-				<version>3.2.14.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-context-support</artifactId>
-				<version>3.2.14.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-webmvc</artifactId>
-				<version>3.2.14.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-tx</artifactId>
-				<version>3.2.14.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -281,17 +281,17 @@
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-config</artifactId>
-				<version>3.2.7.RELEASE</version>
+				<version>3.2.9.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-core</artifactId>
-				<version>3.2.7.RELEASE</version>
+				<version>3.2.9.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-web</artifactId>
-				<version>3.2.7.RELEASE</version>
+				<version>3.2.9.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>javainetlocator</groupId>

--- a/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
@@ -12,7 +12,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd"
 		default-lazy-init="false">
 
 	<!--

--- a/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
@@ -13,8 +13,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:util="http://www.springframework.org/schema/util"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-			http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+			http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd"
 			default-lazy-init="false">
 
 	<util:properties id="version" location="WEB-INF/version.properties" />

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="windows-1252"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <beans xmlns="http://www.springframework.org/schema/beans"  xmlns:sec="http://www.springframework.org/schema/security"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans    http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+		xsi:schemaLocation="http://www.springframework.org/schema/beans    http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
 		                    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 	<bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
 		<sec:filter-chain-map path-type="ant">
@@ -13,7 +13,7 @@
 	<bean id="authenticationManager" class="org.springframework.security.authentication.ProviderManager">
 		<property name="providers">
 			<list>
-				<ref local="preAuthenticatedAuthenticationProvider"/>
+				<ref bean="preAuthenticatedAuthenticationProvider"/>
 			</list>
 		</property>
 	</bean>

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -67,8 +67,6 @@
 		<constructor-arg value="/WEB-INF/web.xml"/>
 	</bean>
 
-	<bean id="servletContext" class="org.springframework.web.context.support.ServletContextFactoryBean"/>
-
 	<bean id="etf" class="org.springframework.security.web.access.ExceptionTranslationFilter">
 		<property name="authenticationEntryPoint" ref="preAuthenticatedProcessingFilterEntryPoint"/>
 	</bean>

--- a/web/src/main/webapp/WEB-INF/spring-probe-servlet.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-servlet.xml
@@ -12,7 +12,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd"
 		default-lazy-init="false">
 	<!--
 		************************* Spring implicit beans *************************

--- a/web/src/main/webapp/WEB-INF/spring-probe-stats.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-stats.xml
@@ -12,7 +12,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd"
 		default-lazy-init="false">
 
 	<!--
@@ -481,13 +481,13 @@
 	<bean name="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers">
 			<list>
-				<ref local="connectorStatsTrigger"/>
-				<ref local="clusterStatsTrigger"/>
-				<ref local="memoryStatsTrigger"/>
-				<ref local="runtimeStatsTrigger"/>
-				<ref local="appStatsTrigger"/>
-				<ref local="datasourceStatsTrigger"/>
-				<ref local="statsSerializerTrigger"/>
+				<ref bean="connectorStatsTrigger"/>
+				<ref bean="clusterStatsTrigger"/>
+				<ref bean="memoryStatsTrigger"/>
+				<ref bean="runtimeStatsTrigger"/>
+				<ref bean="appStatsTrigger"/>
+				<ref bean="datasourceStatsTrigger"/>
+				<ref bean="statsSerializerTrigger"/>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
This pull request will bring the library up to spring 4.  It is dependent on #379 occurring first.  Therefore it's build on top of that pull request.  Spring 4 required quartz 2.x.  So what I would like to do here is wait until the quartz piece is merged before this is then merged.

What is absent in this upgrade is dealing with spring security.

This partially fixes #449 

This patch also brings spring security 3.2.x up to the latest.

Again, hold off merging this until after #379 is merged.  Once that is merged this one is ready to be merged.  If it doens't drop the commits off here I can resubmit it shortly after to ensure we only show exactly what is changing here.