### PR TITLE
Full jdk6 library support - Fixes #581

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,7 +53,7 @@
 			<artifactId>javax.mail-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>c3p0</groupId>
+			<groupId>com.mchange</groupId>
 			<artifactId>c3p0</artifactId>
 			<scope>provided</scope>
 		</dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
+			<artifactId>javax.mail-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>c3p0</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -129,7 +129,7 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.uwyn</groupId>
+			<groupId>org.codelibs</groupId>
 			<artifactId>jhighlight</artifactId>
 			<scope>compile</scope>
 			<exclusions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -180,8 +180,8 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
+			<groupId>org.jboss.spec.javax.transaction</groupId>
+			<artifactId>jboss-transaction-api_1.2_spec</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,6 +116,10 @@
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
+				<exclusion>
+					<artifactId>commons-beanutils-core</artifactId>
+					<groupId>commons-beanutils</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<!--  misc -->

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,14 @@
 			</dependency>
 			<dependency>
 				<groupId>javax.mail</groupId>
-				<artifactId>mail</artifactId>
-				<version>1.4.7</version>
+				<artifactId>javax.mail-api</artifactId>
+				<version>1.5.5</version>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.activation</groupId>
+						<artifactId>activation</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.web</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-fileupload</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -357,9 +357,9 @@
 				<version>1.0</version>
 			</dependency>
 			<dependency>
-				<groupId>c3p0</groupId>
+				<groupId>com.mchange</groupId>
 				<artifactId>c3p0</artifactId>
-				<version>0.9.1.2</version>
+				<version>0.9.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-dbcp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
-				<version>1.8.3</version>
+				<version>1.9.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
 			<dependency>
 				<groupId>commons-dbcp</groupId>
 				<artifactId>commons-dbcp</artifactId>
-				<version>1.3</version>
+				<version>1.4</version>
 			</dependency>
 			<dependency>
 				<groupId>tanukisoft</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.2.2</version>
+				<version>1.3.1</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-log4j12</artifactId>
-				<version>1.7.12</version>
+				<version>1.7.13</version>
 			</dependency>
 			<dependency>
 				<groupId>jaxen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -374,13 +374,7 @@
 			<dependency>
 				<groupId>org.jfree</groupId>
 				<artifactId>jfreechart</artifactId>
-				<version>1.0.15</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.lowagie</groupId>
-						<artifactId>itext</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>1.0.19</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -352,9 +352,9 @@
 				<version>1.4.1</version>
 			</dependency>
 			<dependency>
-				<groupId>com.uwyn</groupId>
+				<groupId>org.codelibs</groupId>
 				<artifactId>jhighlight</artifactId>
-				<version>1.0</version>
+				<version>1.0.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.mchange</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>1.4</version>
+				<version>2.4</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 			<dependency>
 				<groupId>org.apache.openejb</groupId>
 				<artifactId>openejb-core</artifactId>
-				<version>4.7.1</version>
+				<version>4.7.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.jolbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>
 				<artifactId>xstream</artifactId>
-				<version>1.4.1</version>
+				<version>1.4.8</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codelibs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -316,9 +316,9 @@
 				<version>2.18</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.transaction</groupId>
-				<artifactId>jta</artifactId>
-				<version>1.1</version>
+				<groupId>org.jboss.spec.javax.transaction</groupId>
+				<artifactId>jboss-transaction-api_1.2_spec</artifactId>
+				<version>1.0.0.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
Bring all libraries up to latest support to resolve version eyes reporting including 5 vulnerabilities now listed on master README badge for versioneyes.

Fixes #581 