### PR TITLE
Per Sonar analysis, add missing libraries and correct java mail usage - Fixes #587

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,6 +32,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-coyote</artifactId>
+			<version>7.0.67</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-jasper</artifactId>
 			<version>7.0.67</version>
 			<scope>provided</scope>
@@ -49,8 +55,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>javax.mail-api</artifactId>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.mchange</groupId>
@@ -258,6 +264,12 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.1</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
 				<version>1.2.1</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.mail</groupId>
-				<artifactId>javax.mail-api</artifactId>
+				<groupId>com.sun.mail</groupId>
+				<artifactId>javax.mail</artifactId>
 				<version>1.5.5</version>
 				<exclusions>
 					<exclusion>

--- a/tomcat70adapter/pom.xml
+++ b/tomcat70adapter/pom.xml
@@ -42,12 +42,18 @@
 			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
-                <dependency>
-                        <groupId>org.apache.tomcat</groupId>
-                        <artifactId>tomcat-dbcp</artifactId>
-                        <version>${tomcat.version}</version>
-                        <scope>provided</scope>                        
-                </dependency>                                
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-coyote</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-dbcp</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-jasper</artifactId>


### PR DESCRIPTION
Java mail doesn't come with tomcat so usage of it requires we utilize
the implementation and api not just the api.

This fixes #587 