### PR TITLE
Update maven plugins and dependencies to java 7 - Fixes #585

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
 				<plugin>
 					<groupId>pl.project13.maven</groupId>
 					<artifactId>git-commit-id-plugin</artifactId>
-					<version>2.1.15</version>
+					<version>2.2.0</version>
 					<configuration>
 						<dotGitDirectory>${git.relative.path}.git</dotGitDirectory>
 						<gitDescribe>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
-							<version>6.10.1</version>
+							<version>6.14.1</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -563,10 +563,7 @@
 				<plugin>
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>3.2.1</version>
-					<configuration>
-						<sourceEncoding>UTF-8</sourceEncoding>
-					</configuration>
+					<version>4.1.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
Fixes #585 

We are still targetting java 6 on our builds.  This is for git commit id plugin, coveralls, and checkstyles.  Each now require java 7 and otherwise do not affect our outcome.  These additionally, go towards making version eyes see the library as up to date.