### PR TITLE
Java Language Cleanups - Use package protected properties

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/providers/MultipleSeriesProvider.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/providers/MultipleSeriesProvider.java
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 public class MultipleSeriesProvider extends AbstractSeriesProvider {
   
   /** The stat name prefix. */
-  private String statNamePrefix;
+  String statNamePrefix;
   
   /** The top. */
   private int top = 0;

--- a/core/src/main/java/com/googlecode/psiprobe/tools/AsyncSocketFactory.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/AsyncSocketFactory.java
@@ -74,19 +74,19 @@ public class AsyncSocketFactory {
   static class SocketWrapper {
 
     /** The socket. */
-    private Socket socket = null;
+    Socket socket = null;
     
     /** The server. */
-    private String server;
+    String server;
     
     /** The port. */
-    private int port;
+    int port;
     
     /** The exception. */
-    private IOException exception;
+    IOException exception;
     
     /** The valid. */
-    private boolean valid = true;
+    boolean valid = true;
 
     /**
      * Gets the socket.

--- a/core/src/main/java/com/googlecode/psiprobe/tools/Whois.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/Whois.java
@@ -142,16 +142,16 @@ public class Whois {
   public static class Response {
 
     /** The summary. */
-    private String summary;
+    String summary;
     
     /** The data. */
-    private Map<String, String> data = new TreeMap<String, String>();
+    Map<String, String> data = new TreeMap<String, String>();
     
     /** The server. */
-    private String server;
+    String server;
     
     /** The port. */
-    private int port;
+    int port;
 
     /**
      * Gets the summary.


### PR DESCRIPTION
Use package protected properties that are used by inner classes.