### PR TITLE
Java Language Cleanups - Micro Updates

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
@@ -316,7 +316,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
              * and /WEB-INF/lib. JspCompilationContext would only take URLClassLoader, so we fake it
              */
             URLClassLoader classLoader =
-                new URLClassLoader(new URL[] {}, context.getLoader().getClassLoader());
+                new URLClassLoader(new URL[0], context.getLoader().getClassLoader());
             for (String name : names) {
               long time = System.currentTimeMillis();
               JspCompilationContext jcctx =
@@ -382,7 +382,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
            * and /WEB-INF/lib. JspCompilationContext would only take URLClassLoader, so we fake it
            */
           URLClassLoader urlcl = new URLClassLoader(
-              new URL[] {}, context.getLoader().getClassLoader());
+              new URL[0], context.getLoader().getClassLoader());
           
           compileItem("/", opt, context, jrctx, summary, urlcl, 0, compile);
         } finally {

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AbstractStatsCollectorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AbstractStatsCollectorBean.java
@@ -190,6 +190,10 @@ public abstract class AbstractStatsCollectorBean {
    */
   private class Entry {
     
+    public Entry() {
+      // Prevent Emulation by Synthetic Accessor
+    }
+
     /** The time. */
     long time;
     

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
@@ -45,11 +45,6 @@ public class MemoryPoolMailingListener extends FlapListener implements MessageSo
   private Mailer mailer;
 
   /**
-   * Instantiates a new memory pool mailing listener.
-   */
-  public MemoryPoolMailingListener() {}
-
-  /**
    * Gets the message source accessor.
    *
    * @return the message source accessor

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/StatsCollectionEvent.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/StatsCollectionEvent.java
@@ -29,7 +29,9 @@ public class StatsCollectionEvent {
   /**
    * Instantiates a new stats collection event.
    */
-  public StatsCollectionEvent() {}
+  public StatsCollectionEvent() {
+    // Required due to override
+  }
 
   /**
    * Instantiates a new stats collection event.

--- a/core/src/main/java/com/googlecode/psiprobe/model/IpInfo.java
+++ b/core/src/main/java/com/googlecode/psiprobe/model/IpInfo.java
@@ -29,7 +29,9 @@ public class IpInfo {
   /**
    * Instantiates a new ip info.
    */
-  public IpInfo() {}
+  public IpInfo() {
+    // Required due to override
+  }
 
   /**
    * Instantiates a new ip info.

--- a/core/src/main/java/com/googlecode/psiprobe/model/sql/DataSourceTestInfo.java
+++ b/core/src/main/java/com/googlecode/psiprobe/model/sql/DataSourceTestInfo.java
@@ -45,11 +45,6 @@ public class DataSourceTestInfo implements Serializable {
   int historySize = 0;
 
   /**
-   * Instantiates a new data source test info.
-   */
-  public DataSourceTestInfo() {}
-
-  /**
    * Adds the query to history.
    *
    * @param sql the sql

--- a/core/src/main/java/com/googlecode/psiprobe/tokenizer/StringTokenizer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tokenizer/StringTokenizer.java
@@ -24,7 +24,9 @@ public class StringTokenizer extends Tokenizer {
   /**
    * Instantiates a new string tokenizer.
    */
-  public StringTokenizer() {}
+  public StringTokenizer() {
+    // Required due to override
+  }
 
   /**
    * Instantiates a new string tokenizer.

--- a/core/src/main/java/com/googlecode/psiprobe/tools/AccessorFactory.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/AccessorFactory.java
@@ -19,11 +19,6 @@ package com.googlecode.psiprobe.tools;
 public class AccessorFactory {
 
   /**
-   * Instantiates a new accessor factory.
-   */
-  private AccessorFactory() {}
-
-  /**
    * Gets the single instance of AccessorFactory.
    *
    * @return single instance of AccessorFactory

--- a/core/src/main/java/com/googlecode/psiprobe/tools/SecurityUtils.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/SecurityUtils.java
@@ -29,11 +29,6 @@ import javax.servlet.http.HttpServletRequest;
 public class SecurityUtils {
 
   /**
-   * Instantiates a new security utils.
-   */
-  private SecurityUtils() {}
-
-  /**
    * Checks for attribute value role.
    *
    * @param servletContext the servlet context

--- a/core/src/main/java/com/googlecode/psiprobe/tools/TimeoutException.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/TimeoutException.java
@@ -23,9 +23,4 @@ public class TimeoutException extends IOException {
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = 1L;
 
-  /**
-   * Instantiates a new timeout exception.
-   */
-  public TimeoutException() {}
-
 }

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/DefaultAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/DefaultAccessor.java
@@ -111,7 +111,7 @@ public class DefaultAccessor {
   protected Object invokeMethod(Object object, String name, Object param, Object defaultValue) {
     try {
       if (param == null) {
-        return MethodUtils.invokeMethod(object, name, new Object[] {});
+        return MethodUtils.invokeMethod(object, name, new Object[0]);
       }
       return MethodUtils.invokeMethod(object, name, param);
     } catch (Exception e) {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
@@ -43,7 +43,7 @@ public class Jdk14ManagerAccessor extends DefaultAccessor {
       IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 
     Class clazz = cl.loadClass("java.util.logging.LogManager");
-    Method getManager = MethodUtils.getAccessibleMethod(clazz, "getLogManager", new Class[] {});
+    Method getManager = MethodUtils.getAccessibleMethod(clazz, "getLogManager", new Class[0]);
     Object manager = getManager.invoke(null);
     if (manager == null) {
       throw new NullPointerException(clazz.getName() + ".getLogManager() returned null");

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
@@ -52,7 +52,7 @@ public class Log4JManagerAccessor extends DefaultAccessor {
     try {
       Class clazz = (Class) getTarget();
       Method getRootLogger = MethodUtils
-          .getAccessibleMethod(clazz, "getRootLogger", new Class[] {});
+          .getAccessibleMethod(clazz, "getRootLogger", new Class[0]);
       
       Object logger = getRootLogger.invoke(null);
       if (logger == null) {
@@ -108,7 +108,7 @@ public class Log4JManagerAccessor extends DefaultAccessor {
 
       Class clazz = (Class) getTarget();
       Method getCurrentLoggers = MethodUtils
-          .getAccessibleMethod(clazz, "getCurrentLoggers", new Class[] {});
+          .getAccessibleMethod(clazz, "getCurrentLoggers", new Class[0]);
       
       Enumeration currentLoggers = (Enumeration) getCurrentLoggers.invoke(null);
       while (currentLoggers.hasMoreElements()) {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
@@ -50,10 +50,10 @@ public class LogbackFactoryAccessor extends DefaultAccessor {
 
     // Get the singleton SLF4J binding, which may or may not be Logback, depending on the binding.
     Class clazz = cl.loadClass("org.slf4j.impl.StaticLoggerBinder");
-    Method getSingleton = MethodUtils.getAccessibleMethod(clazz, "getSingleton", new Class[] {});
+    Method getSingleton = MethodUtils.getAccessibleMethod(clazz, "getSingleton", new Class[0]);
     Object singleton = getSingleton.invoke(null);
     Method getLoggerFactory = MethodUtils
-        .getAccessibleMethod(clazz, "getLoggerFactory", new Class[] {});
+        .getAccessibleMethod(clazz, "getLoggerFactory", new Class[0]);
     
     Object loggerFactory = getLoggerFactory.invoke(singleton);
 
@@ -113,7 +113,7 @@ public class LogbackFactoryAccessor extends DefaultAccessor {
     try {
       Class clazz = getTarget().getClass();
       Method getLoggerList = MethodUtils
-          .getAccessibleMethod(clazz, "getLoggerList", new Class[] {});
+          .getAccessibleMethod(clazz, "getLoggerList", new Class[0]);
       
       List<Object> loggers = (List<Object>) getLoggerList.invoke(getTarget());
       Iterator<Object> it = loggers.iterator();

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
@@ -51,10 +51,10 @@ public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
 
     // Get the singleton SLF4J binding, which may or may not be Logback, depending on the binding.
     Class clazz = cl.loadClass("org.apache.juli.logging.org.slf4j.impl.StaticLoggerBinder");
-    Method getSingleton = MethodUtils.getAccessibleMethod(clazz, "getSingleton", new Class[] {});
+    Method getSingleton = MethodUtils.getAccessibleMethod(clazz, "getSingleton", new Class[0]);
     Object singleton = getSingleton.invoke(null);
     Method getLoggerFactory = MethodUtils
-        .getAccessibleMethod(clazz, "getLoggerFactory", new Class[] {});
+        .getAccessibleMethod(clazz, "getLoggerFactory", new Class[0]);
     
     Object loggerFactory = getLoggerFactory.invoke(singleton);
 
@@ -119,7 +119,7 @@ public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
     try {
       Class clazz = getTarget().getClass();
       Method getLoggerList = MethodUtils
-          .getAccessibleMethod(clazz, "getLoggerList", new Class[] {});
+          .getAccessibleMethod(clazz, "getLoggerList", new Class[0]);
       
       List<Object> loggers = (List<Object>) getLoggerList.invoke(getTarget());
       Iterator<Object> it = loggers.iterator();


### PR DESCRIPTION
Prevent Synthetic Accessor by adding constructor
Add empty arrays as [0] instead of [] {} for example new URL[0] instead of new URL[] {}
Remove Unnecessary constructors
Comment required contructors where constructors are overridden
