### PR TITLE
Java Language Cleanups - Use StringBuilder rather than StringBuffer

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/Utils.java
+++ b/core/src/main/java/com/googlecode/psiprobe/Utils.java
@@ -111,7 +111,7 @@ public class Utils {
       charset = Charset.forName(charsetName);
     }
 
-    StringBuffer out = new StringBuffer();
+    StringBuilder out = new StringBuilder();
     BufferedReader reader = new BufferedReader(new InputStreamReader(is, charset), 4096);
     try {
       String line;
@@ -461,7 +461,7 @@ public class Utils {
       // we number the lines we could end up with a line number and no line
       // to avoid that we just ignore the first line alltogether.
       //
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       long counter = 0;
       while (tokenizer.hasMore()) {
         Token tk = tokenizer.nextToken();
@@ -491,7 +491,7 @@ public class Utils {
    * @return the string
    */
   public static String leftPad(String str, int len, String fill) {
-    StringBuffer sb = new StringBuffer(len);
+    StringBuilder sb = new StringBuilder(len);
     if (str.length() < len) {
       for (int i = str.length(); i < len; i++) {
         sb.append(fill);
@@ -513,7 +513,7 @@ public class Utils {
     String language = locale.getLanguage();
     String country = locale.getCountry();
     String variant = locale.getVariant();
-    StringBuffer temp = new StringBuffer(baseName);
+    StringBuilder temp = new StringBuilder(baseName);
 
     if (language.length() > 0) {
       temp.append('_').append(language);

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/AddQueryParamTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/AddQueryParamTag.java
@@ -43,7 +43,7 @@ public class AddQueryParamTag extends TagSupport {
 
   @Override
   public int doStartTag() throws JspException {
-    StringBuffer query = new StringBuffer();
+    StringBuilder query = new StringBuilder();
     query.append(param).append("=").append(value);
     for (Enumeration<String> en = pageContext.getRequest().getParameterNames(); en.hasMoreElements();) {
       String name = en.nextElement();

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/ParamToggleTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/ParamToggleTag.java
@@ -44,7 +44,7 @@ public class ParamToggleTag extends TagSupport {
   public int doStartTag() throws JspException {
     boolean getSize =
         ServletRequestUtils.getBooleanParameter(pageContext.getRequest(), param, false);
-    StringBuffer query = new StringBuffer();
+    StringBuilder query = new StringBuilder();
     query.append(param).append("=").append(!getSize);
     String encoding = pageContext.getResponse().getCharacterEncoding();
     for (Enumeration<String> en = pageContext.getRequest().getParameterNames(); en.hasMoreElements();) {

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/VisualScoreTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/VisualScoreTag.java
@@ -98,11 +98,11 @@ public class VisualScoreTag extends BodyTagSupport {
     BodyContent bc = getBodyContent();
     String body = bc.getString().trim();
 
-    StringBuffer buf = calculateSuffix(body);
+    String buf = calculateSuffix(body);
 
     try {
       JspWriter out = bc.getEnclosingWriter();
-      out.print(buf.toString());
+      out.print(buf);
     } catch (IOException ioe) {
       throw new JspException("Error:IOException while writing to client" + ioe.getMessage());
     }
@@ -116,7 +116,7 @@ public class VisualScoreTag extends BodyTagSupport {
    * @param body the body
    * @return the string buffer
    */
-  StringBuffer calculateSuffix(String body) {
+  String calculateSuffix(String body) {
     if (value < minValue) {
       log.info("value " + value + " is less than min value " + minValue);
       value = minValue;
@@ -146,7 +146,7 @@ public class VisualScoreTag extends BodyTagSupport {
     int bluePart2 = (int) Math.floor(
         (value2 - (blueWhole * blockWidth) - (bluePart1 * unitSize)) / unitSize);
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
 
     // Beginning
     if (showA) {
@@ -209,7 +209,7 @@ public class VisualScoreTag extends BodyTagSupport {
       buf.append(MessageFormat.format(body, new Object[] {format}));
     }
 
-    return buf;
+    return buf.toString();
   }
 
   /**

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/VisualScoreTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/VisualScoreTagTest.java
@@ -52,7 +52,7 @@ public class VisualScoreTagTest extends TestCase {
             value2 = Integer.parseInt(values[1]);
             if (value > 5 || value2 > 5) {
               count++;
-              StringBuffer msg = new StringBuffer();
+              StringBuilder msg = new StringBuilder();
               msg.append("Found incorrect value ");
               msg.append(suffix);
               msg.append(". value = ");
@@ -98,9 +98,9 @@ public class VisualScoreTagTest extends TestCase {
     visualScoreTag.setValue(value);
     visualScoreTag.setValue2(value2);
 
-    StringBuffer buf = visualScoreTag.calculateSuffix(body);
+    String buf = visualScoreTag.calculateSuffix(body);
 
-    return buf.toString().split(" ");
+    return buf.split(" ");
   }
 
 }


### PR DESCRIPTION
Use StringBuilder() instead of StringBuffer().  It is not possible everywhere as some are improperly used at class level and thus require synchronization.  Therefore remaining ones will be addressed later by changing their usage to be more in line with modern java practice.