### PR TITLE
Add javabean tester and tests

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/tools/MailMessage.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/MailMessage.java
@@ -48,6 +48,13 @@ public class MailMessage {
 
   /**
    * Instantiates a new mail message.
+   */
+  public MailMessage() {
+    // Require Due To Override
+  }
+
+  /**
+   * Instantiates a new mail message.
    *
    * @param to the to
    * @param subject the subject

--- a/core/src/main/java/com/googlecode/psiprobe/tools/url/UrlParser.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/url/UrlParser.java
@@ -34,6 +34,13 @@ public class UrlParser {
 
   /**
    * Instantiates a new url parser.
+   */
+  public UrlParser() {
+    // Required due to override
+  }
+
+  /**
+   * Instantiates a new url parser.
    *
    * @param url the url
    * @throws MalformedURLException the malformed url exception

--- a/core/src/test/java/com/googlecode/psiprobe/beans/ContainerWrapperBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/ContainerWrapperBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ContainerWrapperBeanTest.
+ */
+public class ContainerWrapperBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ContainerWrapperBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AppStatsCollectorBeanTest.
+ */
+public class AppStatsCollectorBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(AppStatsCollectorBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/ClusterStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/ClusterStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ClusterStatsCollectorBeanTest.
+ */
+public class ClusterStatsCollectorBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ClusterStatsCollectorBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/ConnectorStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/ConnectorStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ConnectorStatsCollectorBeanTest.
+ */
+public class ConnectorStatsCollectorBeanTest {
+
+    /**
+     * Javabean tester.
+     */
+    @Test
+    public void javabeanTester() {
+      JavaBeanTester.builder(ConnectorStatsCollectorBean.class).loadData().test();
+    }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DatasourceStatsCollectorBeanTest.
+ */
+public class DatasourceStatsCollectorBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DatasourceStatsCollectorBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/JvmMemoryStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/JvmMemoryStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class JvmMemoryStatsCollectorBeanTest.
+ */
+public class JvmMemoryStatsCollectorBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(JvmMemoryStatsCollectorBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/RuntimeStatsCollectorBeanTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/collectors/RuntimeStatsCollectorBeanTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.collectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class RuntimeStatsCollectorBeanTest.
+ */
+public class RuntimeStatsCollectorBeanTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(RuntimeStatsCollectorBean.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/MemoryPoolMailingListenerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/MemoryPoolMailingListenerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.listeners;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class MemoryPoolMailingListenerTest.
+ */
+public class MemoryPoolMailingListenerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(MemoryPoolMailingListener.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/StatsCollectionEventTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/listeners/StatsCollectionEventTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.listeners;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class StatsCollectionEventTest.
+ */
+public class StatsCollectionEventTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(StatsCollectionEvent.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/providers/MultipleSeriesProviderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/providers/MultipleSeriesProviderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.providers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class MultipleSeriesProviderTest.
+ */
+public class MultipleSeriesProviderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(MultipleSeriesProvider.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/beans/stats/providers/StandardSeriesProviderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/beans/stats/providers/StandardSeriesProviderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.beans.stats.providers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class StandardSeriesProviderTest.
+ */
+public class StandardSeriesProviderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(StandardSeriesProvider.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/BeanToXmlControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/BeanToXmlControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class BeanToXmlControllerTest.
+ */
+public class BeanToXmlControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(BeanToXmlController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/DecoratorControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/DecoratorControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DecoratorControllerTest.
+ */
+public class DecoratorControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DecoratorController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/ErrorHandlerControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/ErrorHandlerControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ErrorHandlerControllerTest.
+ */
+public class ErrorHandlerControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ErrorHandlerController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/RenderChartControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/RenderChartControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class RenderChartControllerTest.
+ */
+public class RenderChartControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(RenderChartController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/TomcatAvailabilityControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/TomcatAvailabilityControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class TomcatAvailabilityControllerTest.
+ */
+public class TomcatAvailabilityControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(TomcatAvailabilityController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/WhoisControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/WhoisControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class WhoisControllerTest.
+ */
+public class WhoisControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(WhoisController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/AllAppStatsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/AllAppStatsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AllAppStatsControllerTest.
+ */
+public class AllAppStatsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(AllAppStatsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/DownloadXmlConfControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/DownloadXmlConfControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DownloadXmlConfControllerTest.
+ */
+public class DownloadXmlConfControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DownloadXmlConfController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/GetApplicationControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/GetApplicationControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class GetApplicationControllerTest.
+ */
+public class GetApplicationControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(GetApplicationController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/NoSelfContextHandlerControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/NoSelfContextHandlerControllerTest.java
@@ -1,0 +1,22 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class NoSelfContextHandlerControllerTest.
+ */
+public class NoSelfContextHandlerControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Ignore
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(NoSelfContextHandlerController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/ResetAppStatsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/ResetAppStatsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ResetAppStatsControllerTest.
+ */
+public class ResetAppStatsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ResetAppStatsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/apps/ViewXmlConfControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/apps/ViewXmlConfControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.apps;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ViewXmlConfControllerTest.
+ */
+public class ViewXmlConfControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ViewXmlConfController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/cluster/ClusterStatsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/cluster/ClusterStatsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.cluster;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ClusterStatsControllerTest.
+ */
+public class ClusterStatsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ClusterStatsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/GetConnectorControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/GetConnectorControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.connectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class GetConnectorControllerTest.
+ */
+public class GetConnectorControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(GetConnectorController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ListConnectorsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ListConnectorsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.connectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ListConnectorsControllerTest.
+ */
+public class ListConnectorsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ListConnectorsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ResetConnectorStatsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ResetConnectorStatsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.connectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ResetConnectorStatsControllerTest.
+ */
+public class ResetConnectorStatsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ResetConnectorStatsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ZoomChartControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/connectors/ZoomChartControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.connectors;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ZoomChartControllerTest.
+ */
+public class ZoomChartControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ZoomChartController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/datasources/ResetDataSourceControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/datasources/ResetDataSourceControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.datasources;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ResetDataSourceControllerTest.
+ */
+public class ResetDataSourceControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ResetDataSourceController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/deploy/UndeployContextControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/deploy/UndeployContextControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.deploy;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class UndeployContextControllerTest.
+ */
+public class UndeployContextControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(UndeployContextController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/logs/ListLogsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/logs/ListLogsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.logs;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ListLogsControllerTest.
+ */
+public class ListLogsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ListLogsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/logs/LogHandlerControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/logs/LogHandlerControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.logs;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class LogHandlerControllerTest.
+ */
+public class LogHandlerControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(LogHandlerController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/sql/DataSourceTestControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/sql/DataSourceTestControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.sql;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DataSourceTestControllerTest.
+ */
+public class DataSourceTestControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DataSourceTestController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/system/AdviseGarbageCollectionControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/system/AdviseGarbageCollectionControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.system;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AdviseGarbageCollectionControllerTest.
+ */
+public class AdviseGarbageCollectionControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(AdviseGarbageCollectionController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/system/MemoryStatsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/system/MemoryStatsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.system;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class MemoryStatsControllerTest.
+ */
+public class MemoryStatsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(MemoryStatsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/system/SysInfoControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/system/SysInfoControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.system;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class SysInfoControllerTest.
+ */
+public class SysInfoControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(SysInfoController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ImplSelectorControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ImplSelectorControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.threads;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ImplSelectorControllerTest.
+ */
+public class ImplSelectorControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ImplSelectorController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/threads/KillThreadControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/threads/KillThreadControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.threads;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class KillThreadControllerTest.
+ */
+public class KillThreadControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(KillThreadController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ListThreadPoolsControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ListThreadPoolsControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.threads;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ListThreadPoolsControllerTest.
+ */
+public class ListThreadPoolsControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ListThreadPoolsController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ThreadStackControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/threads/ThreadStackControllerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.controllers.threads;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ThreadStackControllerTest.
+ */
+public class ThreadStackControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ThreadStackController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/controllers/wrapper/StopJvmControllerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/controllers/wrapper/StopJvmControllerTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.psiprobe.controllers.wrapper;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+public class StopJvmControllerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(StopJvmController.class).skip("applicationContext", "supportedMethods").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/AddQueryParamTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/AddQueryParamTagTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AddQueryParamTagTest.
+ */
+public class AddQueryParamTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(AddQueryParamTag.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/DurationTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/DurationTagTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DurationTagTest.
+ */
+public class DurationTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DurationTag.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/OutTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/OutTagTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class OutTagTest.
+ */
+public class OutTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(OutTag.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/ParamToggleTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/ParamToggleTagTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ParamToggleTagTest.
+ */
+public class ParamToggleTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ParamToggleTag.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/VisualScoreTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/VisualScoreTagTest.java
@@ -5,17 +5,27 @@ import static org.junit.Assert.fail;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.codebox.bean.JavaBeanTester;
+
 /**
  * The Class VisualScoreTagTest.
  */
-// TODO 1/18/16 This test was not previously used. It causes a lot of output
-// and crashes travis CI.  Review it's need.
-@Ignore
 public class VisualScoreTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(VisualScoreTag.class).loadData().test();
+  }
 
   /**
    * Test range scan.
    */
+  // TODO 1/18/16 This test was not previously used. It causes a lot of output
+  // and crashes travis CI.  Review it's need.
+  @Ignore
   @Test
   public void testRangeScan() {
     // As used in appRuntimeInfo.jsp
@@ -37,7 +47,7 @@ public class VisualScoreTagTest {
    * @param partialBlocks the partial blocks
    * @param invertLoopIndexes the invert loop indexes
    */
-  private void doTestRangeScan(int fullBlocks, int partialBlocks, boolean invertLoopIndexes) {
+  private static void doTestRangeScan(int fullBlocks, int partialBlocks, boolean invertLoopIndexes) {
     int value;
     int value2;
     int count = 0;
@@ -90,7 +100,7 @@ public class VisualScoreTagTest {
    * @param partialBlocks the partial blocks
    * @return the string[]
    */
-  private String[] callCalculateSuffix(int value, int value2, int fullBlocks, int partialBlocks) {
+  private static String[] callCalculateSuffix(int value, int value2, int fullBlocks, int partialBlocks) {
     String body = "{0} ";
 
     VisualScoreTag visualScoreTag = new VisualScoreTag();

--- a/core/src/test/java/com/googlecode/psiprobe/jsp/VolumeTagTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/jsp/VolumeTagTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class VolumeTagTest.
+ */
+public class VolumeTagTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(VolumeTag.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ApplicationParamTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ApplicationParamTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ApplicationParamTest.
+ */
+public class ApplicationParamTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ApplicationParam.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ApplicationResourceTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ApplicationResourceTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ApplicationResourceTest.
+ */
+public class ApplicationResourceTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ApplicationResource.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ApplicationSessionTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ApplicationSessionTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ApplicationSessionTest.
+ */
+public class ApplicationSessionTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ApplicationSession.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ApplicationTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ApplicationTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ApplicationTest.
+ */
+public class ApplicationTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Application.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/AttributeTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/AttributeTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AttributeTest.
+ */
+public class AttributeTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Attribute.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ConnectorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ConnectorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ConnectorTest.
+ */
+public class ConnectorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Connector.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/DataSourceInfoGroupTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/DataSourceInfoGroupTest.java
@@ -1,0 +1,22 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DataSourceInfoGroupTest.
+ */
+public class DataSourceInfoGroupTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Ignore
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DataSourceInfoGroup.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/DataSourceInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/DataSourceInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DataSourceInfoTest.
+ */
+public class DataSourceInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DataSourceInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/DisconnectedLogDestinationTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/DisconnectedLogDestinationTest.java
@@ -1,0 +1,22 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DisconnectedLogDestinationTest.
+ */
+public class DisconnectedLogDestinationTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Ignore
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DisconnectedLogDestination.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/FilterInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/FilterInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class FilterInfoTest.
+ */
+public class FilterInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(FilterInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/FilterMappingTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/FilterMappingTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class FilterMappingTest.
+ */
+public class FilterMappingTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(FilterMapping.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/IpInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/IpInfoTest.java
@@ -1,0 +1,22 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class IpInfoTest.
+ */
+public class IpInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Ignore
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(IpInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/RequestProcessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/RequestProcessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class RequestProcessorTest.
+ */
+public class RequestProcessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(RequestProcessor.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ServletInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ServletInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ServletInfoTest.
+ */
+public class ServletInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ServletInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ServletMappingTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ServletMappingTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ServletMappingTest.
+ */
+public class ServletMappingTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ServletMapping.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/SessionSearchInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/SessionSearchInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class SessionSearchInfoTest.
+ */
+public class SessionSearchInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(SessionSearchInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/SunThreadTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/SunThreadTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class SunThreadTest.
+ */
+public class SunThreadTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(SunThread.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/SystemInformationTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/SystemInformationTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class SystemInformationTest.
+ */
+public class SystemInformationTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(SystemInformation.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ThreadPoolTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ThreadPoolTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ThreadPoolTest.
+ */
+public class ThreadPoolTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ThreadPool.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/ThreadStackElementTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/ThreadStackElementTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ThreadStackElementTest.
+ */
+public class ThreadStackElementTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ThreadStackElement.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/TomcatTestReportTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/TomcatTestReportTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class TomcatTestReportTest.
+ */
+public class TomcatTestReportTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(TomcatTestReport.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/TransportableModelTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/TransportableModelTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class TransportableModelTest.
+ */
+public class TransportableModelTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(TransportableModel.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/java/ThreadModelTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/java/ThreadModelTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.java;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ThreadModelTest.
+ */
+public class ThreadModelTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ThreadModel.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/AsyncClusterSenderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/AsyncClusterSenderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class AsyncClusterSenderTest.
+ */
+public class AsyncClusterSenderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(AsyncClusterSender.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/ClusterSenderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/ClusterSenderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ClusterSenderTest.
+ */
+public class ClusterSenderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ClusterSender.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/ClusterTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/ClusterTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ClusterTest.
+ */
+public class ClusterTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Cluster.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/MemoryPoolTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/MemoryPoolTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+public class MemoryPoolTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(MemoryPool.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/PooledClusterSenderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/PooledClusterSenderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class PooledClusterSenderTest.
+ */
+public class PooledClusterSenderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(PooledClusterSender.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/RuntimeInformationTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/RuntimeInformationTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class RuntimeInformationTest.
+ */
+public class RuntimeInformationTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+      JavaBeanTester.builder(RuntimeInformation.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/SyncClusterSenderTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/SyncClusterSenderTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class SyncClusterSenderTest.
+ */
+public class SyncClusterSenderTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(SyncClusterSender.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jmx/ThreadPoolObjectNameTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jmx/ThreadPoolObjectNameTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.psiprobe.model.jmx;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+public class ThreadPoolObjectNameTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(ThreadPoolObjectName.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jsp/ItemTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jsp/ItemTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class ItemTest.
+ */
+public class ItemTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Item.class).skip("LastModified").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/jsp/SummaryTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/jsp/SummaryTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.psiprobe.model.jsp;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+public class SummaryTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Summary.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/sql/DataSourceTestInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/sql/DataSourceTestInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.sql;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class DataSourceTestInfoTest.
+ */
+public class DataSourceTestInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DataSourceTestInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/model/wrapper/WrapperInfoTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/model/wrapper/WrapperInfoTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.model.wrapper;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class WrapperInfoTest.
+ */
+public class WrapperInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(WrapperInfo.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/MailMessageTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/MailMessageTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class MailMessageTest.
+ */
+public class MailMessageTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(MailMessage.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/MailerTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/MailerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class MailerTest.
+ */
+public class MailerTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Mailer.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/DefaultAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/DefaultAccessorTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.psiprobe.tools.logging;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+public class DefaultAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DefaultAccessor.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/FileLogAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/FileLogAccessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.logging;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class FileLogAccessorTest.
+ */
+public class FileLogAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(FileLogAccessor.class).loadData().test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14HandlerAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14HandlerAccessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.logging.jdk;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class Jdk14HandlerAccessorTest.
+ */
+public class Jdk14HandlerAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Jdk14HandlerAccessor.class).skip("level").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/log4j/Log4jAppenderAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/log4j/Log4jAppenderAccessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.logging.log4j;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class Log4jAppenderAccessorTest.
+ */
+public class Log4jAppenderAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(Log4JAppenderAccessor.class).skip("level").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/logback/LogbackAppenderAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/logback/LogbackAppenderAccessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.logging.logback;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class LogbackAppenderAccessorTest.
+ */
+public class LogbackAppenderAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(LogbackAppenderAccessor.class).skip("level").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessorTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessorTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.logging.slf4jlogback;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class TomcatSlf4jLogbackAppenderAccessorTest.
+ */
+public class TomcatSlf4jLogbackAppenderAccessorTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(TomcatSlf4jLogbackAppenderAccessor.class).skip("level").test();
+  }
+
+}

--- a/core/src/test/java/com/googlecode/psiprobe/tools/url/UrlParserTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/tools/url/UrlParserTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.psiprobe.tools.url;
+
+import org.junit.Test;
+
+import com.codebox.bean.JavaBeanTester;
+
+/**
+ * The Class UrlParserTest.
+ */
+public class UrlParserTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(UrlParser.class).loadData().test();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 				<version>4.12</version>
 			</dependency>
 			<dependency>
+				<groupId>com.github.hazendaz</groupId>
+				<artifactId>javabean-tester</artifactId>
+				<version>1.4.0</version>
+			</dependency>
+			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
 				<version>3.0.1</version>
@@ -382,6 +387,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.hazendaz</groupId>
+			<artifactId>javabean-tester</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Javabean-tester is a project I own which allows for use of builder pattern to quickly test javabeans (ie POJOs).  Most projects have lots of these including this project.  Based on the low code coverage that currently exists, this is a key way to greatly improve code coverage very quickly and easily.  This has been done across the code base.  Getters and setters are internally verfied that when value is set, the get of that property will return the expected value used in setting.  This guarentees the getters and setters are written correctly.  The only area I skipped adding this was where code coverage already existed.  However, later it might make sense based on how thorough this is to add in those locations as well.