### PR TITLE
Fixes #620 Class path contains multiple SLF4J bindings.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,40 +97,6 @@
 			<groupId>org.apache.openejb</groupId>
 			<artifactId>openejb-core</artifactId>
 			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-lang3</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-pool</groupId>
-					<artifactId>commons-pool</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.openwebbeans</groupId>
-					<artifactId>openwebbeans-impl</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.openejb.patch</groupId>
-					<artifactId>openjpa</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.activemq</groupId>
-					<artifactId>activemq-broker</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<artifactId>commons-beanutils-core</artifactId>
-					<groupId>commons-beanutils</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/core/src/test/java/com/googlecode/psiprobe/LogbackConfigTest.java
+++ b/core/src/test/java/com/googlecode/psiprobe/LogbackConfigTest.java
@@ -1,0 +1,18 @@
+package com.googlecode.psiprobe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogbackConfigTest {
+
+  @Test
+  public void test() {
+    Logger log = LoggerFactory.getLogger(getClass());
+    if ("org.slf4j.impl.JDK14LoggerAdapter".equals(log.getClass().getName())) {
+      fail("slf4j-jdk14-1.7.7.jar is on the classpath, but it should NOT be.");
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
 				<groupId>org.apache.openejb</groupId>
 				<artifactId>openejb-core</artifactId>
 				<version>4.7.3</version>
+				<exclusions>
+					<exclusion>
+						<groupId>*</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.jolbox</groupId>


### PR DESCRIPTION
It excludes slf4j-jdk14 from openejb and create a test to make sure slf4j-jdk14 is no more on the classpath.