### PR TITLE
Remove JMX as it is provided by Java SE since 5.0 - Fixes #615

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -222,11 +222,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.management</groupId>
-			<artifactId>jmxri</artifactId>
-			<scope>${jmxri.scope}</scope>
-		</dependency>
-		<dependency>
 			<groupId>xpp3</groupId>
 			<artifactId>xpp3_min</artifactId>
 			<scope>compile</scope>
@@ -284,20 +279,4 @@
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<jmxri.scope>compile</jmxri.scope>
-			</properties>
-		</profile>
-		<profile>
-			<id>jboss</id>
-			<properties>
-				<jmxri.scope>provided</jmxri.scope>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,6 @@
 	</modules>
 	<repositories>
 		<repository>
-			<!-- Required for jmxri -->
-			<snapshots>
-				<enabled>false</enabled>
-				<updatePolicy>never</updatePolicy>
-			</snapshots>
-			<id>repository.jboss.org</id>
-			<name>repository.jboss.org</name>
-			<url>https://repository.jboss.org/nexus/content/repositories/deprecated/</url>
-			<layout>default</layout>
-		</repository>
-		<repository>
 			<!-- Required for ojdbc6 and ucp -->
 			<snapshots>
 				<enabled>false</enabled>
@@ -340,11 +329,6 @@
 				<groupId>opensymphony</groupId>
 				<artifactId>sitemesh</artifactId>
 				<version>2.4.2</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.management</groupId>
-				<artifactId>jmxri</artifactId>
-				<version>1.2.1</version>
 			</dependency>
 			<dependency>
 				<groupId>xpp3</groupId>


### PR DESCRIPTION
The included one was 12 years old, was causing errors in eclipse with
usage in Jboss resolver, and disabling included one which was completely
modernized and had more features.  Using legacy one would have limited
us going forwards.

Fixes #615 