### PR TITLE
#613 Replace Commons Logging usage with Slf4j and review logging output

### DIFF
--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -33,7 +33,7 @@ public class AjaxToggleContextController extends ContextHandlerController {
 
     if (!request.getContextPath().equals(contextName) && context != null) {
       try {
-        if (context.getAvailable()) {
+        if (context.getState().isAvailable()) {
           logger.info(request.getRemoteAddr() + " requested STOP of " + contextName);
           getContainerWrapper().getTomcatContainer().stop(contextName);
         } else {


### PR DESCRIPTION
This is functional on tomcat 7 and 8.
I did not test it with the others application containers discussed in https://github.com/psi-probe/psi-probe/issues/613#issuecomment-174347172.

This may be breaking something, bit I guess it could be a starting point to replace commons logging.
