### PR TITLE
Fixes #573 Error stopping/starting an app with Probe 2.4 under Tomcat 8

### DIFF
--- a/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/AbstractTomcatContainer.java
@@ -20,8 +20,8 @@ import org.apache.catalina.Host;
 import org.apache.catalina.Valve;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.core.StandardContext;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.modeler.Registry;
 import org.apache.jasper.EmbeddedServletOptions;
 import org.apache.jasper.JasperException;
@@ -58,7 +58,7 @@ import javax.servlet.ServletContext;
 public abstract class AbstractTomcatContainer implements TomcatContainer {
 
   /** The logger. */
-  protected Log logger = LogFactory.getLog(getClass());
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The host. */
   protected Host host;
@@ -406,7 +406,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
   }
 
   @Override
-  public org.apache.juli.logging.Log getLogger(Context context) {
+  public Object getLogger(Context context) {
     return context.getLogger();
   }
 

--- a/core/src/main/java/com/googlecode/psiprobe/AwtAppContextClassloaderListener.java
+++ b/core/src/main/java/com/googlecode/psiprobe/AwtAppContextClassloaderListener.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 import javax.servlet.ServletContextEvent;
@@ -58,7 +58,7 @@ public class AwtAppContextClassloaderListener implements ServletContextListener 
         Thread.currentThread().setContextClassLoader(active);
       }
     } catch (Throwable t) {
-      Log logger = LogFactory.getLog(AwtAppContextClassloaderListener.class.getName());
+      Logger logger = LoggerFactory.getLogger(AwtAppContextClassloaderListener.class.getName());
       logger.error("Failed to address PermGen leak.", t);
     }
   }

--- a/core/src/main/java/com/googlecode/psiprobe/ProbeServlet.java
+++ b/core/src/main/java/com/googlecode/psiprobe/ProbeServlet.java
@@ -15,6 +15,8 @@ import com.googlecode.psiprobe.beans.ContainerWrapperBean;
 
 import org.apache.catalina.ContainerServlet;
 import org.apache.catalina.Wrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.DispatcherServlet;
 
 import javax.servlet.ServletConfig;
@@ -31,6 +33,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Mark Lewis
  */
 public class ProbeServlet extends DispatcherServlet implements ContainerServlet {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = 1L;

--- a/core/src/main/java/com/googlecode/psiprobe/Utils.java
+++ b/core/src/main/java/com/googlecode/psiprobe/Utils.java
@@ -18,8 +18,8 @@ import com.googlecode.psiprobe.tokenizer.TokenizerSymbol;
 
 import com.uwyn.jhighlight.renderer.Renderer;
 import com.uwyn.jhighlight.renderer.XhtmlRendererFactory;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.modeler.Registry;
 
 import java.io.BufferedReader;
@@ -55,7 +55,7 @@ import javax.servlet.http.HttpServletResponse;
 public class Utils {
 
   /** The logger. */
-  private static Log logger = LogFactory.getLog(Utils.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(Utils.class.getName());
 
   /**
    * Calc pool usage score.

--- a/core/src/main/java/com/googlecode/psiprobe/beans/ContainerListenerBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ContainerListenerBean.java
@@ -18,8 +18,8 @@ import com.googlecode.psiprobe.model.jmx.ThreadPoolObjectName;
 import com.googlecode.psiprobe.tools.JmxTools;
 
 import net.sf.javainetlocator.InetAddressLocator;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import javax.management.RuntimeOperationsException;
 public class ContainerListenerBean implements NotificationListener {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
   
   /** The pool names. */
   private List<ThreadPoolObjectName> poolNames = null;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/ContainerWrapperBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ContainerWrapperBean.java
@@ -17,8 +17,8 @@ import com.googlecode.psiprobe.model.ApplicationResource;
 import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.util.ServerInfo;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ import java.util.Map;
 public class ContainerWrapperBean {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The tomcat container. */
   private TomcatContainer tomcatContainer;
@@ -114,7 +114,7 @@ public class ContainerWrapperBean {
           }
 
           if (tomcatContainer == null) {
-            logger.fatal("No suitable container adapter found!");
+            logger.error("No suitable container adapter found!");
           }
         }
       }

--- a/core/src/main/java/com/googlecode/psiprobe/beans/JBossResourceResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/JBossResourceResolverBean.java
@@ -15,8 +15,8 @@ import com.googlecode.psiprobe.model.ApplicationResource;
 import com.googlecode.psiprobe.model.DataSourceInfo;
 
 import org.apache.catalina.Context;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -41,7 +41,7 @@ import javax.sql.DataSource;
 public class JBossResourceResolverBean implements ResourceResolver {
 
   /** The logger. */
-  protected Log logger = LogFactory.getLog(getClass());
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   public MBeanServer getMBeanServer() {
@@ -134,7 +134,7 @@ public class JBossResourceResolverBean implements ResourceResolver {
           resources.add(resource);
         }
       } catch (Exception e) {
-        logger.fatal("There was an error querying JBoss JMX server:", e);
+        logger.error("There was an error querying JBoss JMX server:", e);
       }
     }
     return resources;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/JvmMemoryInfoAccessorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/JvmMemoryInfoAccessorBean.java
@@ -14,8 +14,8 @@ package com.googlecode.psiprobe.beans;
 import com.googlecode.psiprobe.model.jmx.MemoryPool;
 import com.googlecode.psiprobe.tools.JmxTools;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.modeler.Registry;
 
 import java.util.LinkedList;
@@ -35,7 +35,7 @@ import javax.management.openmbean.CompositeDataSupport;
 public class JvmMemoryInfoAccessorBean {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(this.getClass());
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   /**
    * Gets the pools.

--- a/core/src/main/java/com/googlecode/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/LogResolverBean.java
@@ -29,8 +29,8 @@ import com.googlecode.psiprobe.tools.logging.slf4jlogback.TomcatSlf4jLogbackFact
 import com.googlecode.psiprobe.tools.logging.slf4jlogback.TomcatSlf4jLogbackLoggerAccessor;
 
 import org.apache.catalina.Context;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.ClassUtils;
 
 import java.io.File;
@@ -48,7 +48,7 @@ import java.util.List;
 public class LogResolverBean {
 
   /** The logger. */
-  protected final Log logger = LogFactory.getLog(getClass());
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The container wrapper. */
   private ContainerWrapperBean containerWrapper;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/ResourceResolverBean.java
@@ -17,8 +17,8 @@ import com.googlecode.psiprobe.model.DataSourceInfo;
 import org.apache.catalina.Context;
 import org.apache.catalina.Server;
 import org.apache.catalina.core.StandardServer;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.modeler.Registry;
 
 import java.util.ArrayList;
@@ -42,7 +42,7 @@ import javax.sql.DataSource;
 public class ResourceResolverBean implements ResourceResolver {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
    * The default resource prefix for JNDI objects in the global scope: <code>java:</code>.

--- a/core/src/main/java/com/googlecode/psiprobe/beans/RuntimeInfoAccessorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/RuntimeInfoAccessorBean.java
@@ -14,8 +14,8 @@ package com.googlecode.psiprobe.beans;
 import com.googlecode.psiprobe.model.jmx.RuntimeInformation;
 import com.googlecode.psiprobe.tools.JmxTools;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.modeler.Registry;
 
 import javax.management.MBeanServer;
@@ -30,7 +30,7 @@ import javax.management.ObjectName;
 public class RuntimeInfoAccessorBean {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(RuntimeInfoAccessorBean.class);
+  private final Logger logger = LoggerFactory.getLogger(RuntimeInfoAccessorBean.class);
 
   /**
    * Gets the runtime information.

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
@@ -17,8 +17,8 @@ import com.googlecode.psiprobe.model.Application;
 import com.googlecode.psiprobe.tools.ApplicationUtils;
 
 import org.apache.catalina.Context;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.ServletContextAware;
 
@@ -34,7 +34,7 @@ public class AppStatsCollectorBean extends AbstractStatsCollectorBean implements
     ServletContextAware {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(AppStatsCollectorBean.class);
+  private final Logger logger = LoggerFactory.getLogger(AppStatsCollectorBean.class);
 
   /** The container wrapper. */
   private ContainerWrapperBean containerWrapper;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
@@ -15,8 +15,8 @@ import com.googlecode.psiprobe.beans.ContainerWrapperBean;
 import com.googlecode.psiprobe.model.ApplicationResource;
 import com.googlecode.psiprobe.model.DataSourceInfo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class DatasourceStatsCollectorBean.
@@ -32,7 +32,7 @@ public class DatasourceStatsCollectorBean extends AbstractStatsCollectorBean {
   private static final String PREFIX_BUSY = "ds.busy.";
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(DatasourceStatsCollectorBean.class);
+  private final Logger logger = LoggerFactory.getLogger(DatasourceStatsCollectorBean.class);
   
   /** The container wrapper. */
   private ContainerWrapperBean containerWrapper;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/AbstractStatsCollectionListener.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/listeners/AbstractStatsCollectionListener.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.beans.stats.listeners;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The listener interface for receiving abstractStatsCollection events.
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
 public abstract class AbstractStatsCollectionListener implements StatsCollectionListener {
 
   /** The logger. */
-  protected Log logger = LogFactory.getLog(getClass());
+  protected Logger logger = LoggerFactory.getLogger(getClass());
   
   /** The property category. */
   private String propertyCategory;

--- a/core/src/main/java/com/googlecode/psiprobe/beans/stats/providers/AbstractSeriesProvider.java
+++ b/core/src/main/java/com/googlecode/psiprobe/beans/stats/providers/AbstractSeriesProvider.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.beans.stats.providers;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jfree.data.xy.XYDataItem;
 import org.jfree.data.xy.XYSeries;
 
@@ -27,7 +27,7 @@ import java.util.List;
 public abstract class AbstractSeriesProvider implements SeriesProvider {
 
   /** The logger. */
-  protected Log logger = LogFactory.getLog(getClass());
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
    * To series.

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/ContextHandlerController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/ContextHandlerController.java
@@ -12,6 +12,8 @@
 package com.googlecode.psiprobe.controllers;
 
 import org.apache.catalina.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -25,6 +27,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Mark Lewis
  */
 public abstract class ContextHandlerController extends TomcatContainerController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/RenderChartController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/RenderChartController.java
@@ -24,6 +24,8 @@ import org.jfree.chart.renderer.xy.XYAreaRenderer;
 import org.jfree.chart.renderer.xy.XYLine3DRenderer;
 import org.jfree.data.xy.DefaultTableXYDataset;
 import org.jfree.ui.RectangleInsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -54,6 +56,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class RenderChartController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The stats collection. */
   private StatsCollection statsCollection;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/TomcatContainerController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/TomcatContainerController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers;
 
 import com.googlecode.psiprobe.beans.ContainerWrapperBean;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.mvc.AbstractController;
 
 /**
@@ -21,6 +23,9 @@ import org.springframework.web.servlet.mvc.AbstractController;
  * @author Vlad Ilyushchenko
  */
 public abstract class TomcatContainerController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The container wrapper. */
   private ContainerWrapperBean containerWrapper;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/WhoisController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/WhoisController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers;
 
 import com.googlecode.psiprobe.tools.Whois;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -35,6 +37,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class WhoisController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The lookup timeout. */
   private long lookupTimeout = 5;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -38,7 +38,7 @@ public class AjaxReloadContextController extends ContextHandlerController {
       } catch (ThreadDeath e) {
           throw e;
       } catch (Throwable e) {
-        logger.error(e);
+        logger.error("Error during ajax request to RELOAD of " + contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -33,7 +33,7 @@ public class AjaxToggleContextController extends ContextHandlerController {
 
     if (!request.getContextPath().equals(contextName) && context != null) {
       try {
-        if (context.getAvailable()) {
+        if (context.getState().isAvailable()) {
           logger.info(request.getRemoteAddr() + " requested STOP of " + contextName);
           getContainerWrapper().getTomcatContainer().stop(contextName);
         } else {

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -43,7 +43,7 @@ public class AjaxToggleContextController extends ContextHandlerController {
       } catch (ThreadDeath e) {
           throw e;
       } catch (Throwable e) {
-        logger.error(e);
+        logger.error("Error during ajax request to START/STOP of " + contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/apps/NoSelfContextHandlerController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/apps/NoSelfContextHandlerController.java
@@ -63,7 +63,7 @@ public abstract class NoSelfContextHandlerController extends ContextHandlerContr
       executeAction(contextName);
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());
-      logger.error(e);
+      logger.error("Error during invocation", e);
       return new ModelAndView(new InternalResourceView(getViewName()));
     }
     return new ModelAndView(new RedirectView(request.getContextPath() + getViewName()

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/deploy/UndeployContextController.java
@@ -63,7 +63,7 @@ public class UndeployContextController extends ContextHandlerController {
 
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());
-      logger.error(e);
+      logger.error("Error during undeploy of " + contextName, e);
       return new ModelAndView(new InternalResourceView(getFailureViewName() == null ? getViewName()
           : getFailureViewName()));
     }

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/deploy/UploadWarController.java
@@ -81,7 +81,7 @@ public class UploadWarController extends TomcatContainerController {
           }
         }
       } catch (Exception e) {
-        logger.fatal("Could not process file upload", e);
+        logger.error("Could not process file upload", e);
         request.setAttribute(
             "errorMessage",
             getMessageSourceAccessor().getMessage("probe.src.deploy.war.uploadfailure",

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/logs/ListLogsController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/logs/ListLogsController.java
@@ -34,7 +34,7 @@ public class ListLogsController extends ParameterizableViewController {
   /** The error view. */
   private String errorView;
   
-  /** The log resolver. */
+  /** The Logger resolver. */
   private LogResolverBean logResolver;
 
   /**
@@ -56,18 +56,18 @@ public class ListLogsController extends ParameterizableViewController {
   }
 
   /**
-   * Gets the log resolver.
+   * Gets the Logger resolver.
    *
-   * @return the log resolver
+   * @return the Logger resolver
    */
   public LogResolverBean getLogResolver() {
     return logResolver;
   }
 
   /**
-   * Sets the log resolver.
+   * Sets the Logger resolver.
    *
-   * @param logResolver the new log resolver
+   * @param logResolver the new Logger resolver
    */
   public void setLogResolver(LogResolverBean logResolver) {
     this.logResolver = logResolver;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/logs/LogHandlerController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/logs/LogHandlerController.java
@@ -14,6 +14,8 @@ package com.googlecode.psiprobe.controllers.logs;
 import com.googlecode.psiprobe.beans.LogResolverBean;
 import com.googlecode.psiprobe.tools.logging.LogDestination;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -29,22 +31,25 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class LogHandlerController extends ParameterizableViewController {
 
-  /** The log resolver. */
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
+
+  /** The Logger resolver. */
   private LogResolverBean logResolver;
 
   /**
-   * Gets the log resolver.
+   * Gets the Logger resolver.
    *
-   * @return the log resolver
+   * @return the Logger resolver
    */
   public LogResolverBean getLogResolver() {
     return logResolver;
   }
 
   /**
-   * Sets the log resolver.
+   * Sets the Logger resolver.
    *
-   * @param logResolver the new log resolver
+   * @param logResolver the new Logger resolver
    */
   public void setLogResolver(LogResolverBean logResolver) {
     this.logResolver = logResolver;
@@ -86,11 +91,11 @@ public class LogHandlerController extends ParameterizableViewController {
   }
 
   /**
-   * Handle log file.
+   * Handle Logger file.
    *
    * @param request the request
    * @param response the response
-   * @param logDest the log dest
+   * @param logDest the Logger dest
    * @return the model and view
    * @throws Exception the exception
    */

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/sql/CachedRecordSetController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/sql/CachedRecordSetController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers.sql;
 
 import com.googlecode.psiprobe.model.sql.DataSourceTestInfo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -32,6 +34,9 @@ import javax.servlet.http.HttpSession;
  */
 public class CachedRecordSetController extends ParameterizableViewController {
   
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
+
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,
       HttpServletResponse response) throws Exception {

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/sql/QueryHistoryItemController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/sql/QueryHistoryItemController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers.sql;
 
 import com.googlecode.psiprobe.model.sql.DataSourceTestInfo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -29,6 +31,9 @@ import javax.servlet.http.HttpSession;
  * @author Andy Shapoval
  */
 public class QueryHistoryItemController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/system/AdviseGarbageCollectionController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/system/AdviseGarbageCollectionController.java
@@ -11,6 +11,8 @@
 
 package com.googlecode.psiprobe.controllers.system;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -25,6 +27,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class AdviseGarbageCollectionController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The replace pattern. */
   private String replacePattern;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers.threads;
 
 import com.googlecode.psiprobe.Utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -29,6 +31,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class GetClassLoaderUrlsController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/RestartJvmController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/RestartJvmController.java
@@ -11,6 +11,8 @@
 
 package com.googlecode.psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class RestartJvmController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/StopJvmController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/StopJvmController.java
@@ -11,6 +11,8 @@
 
 package com.googlecode.psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class StopJvmController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The stop exit code. */
   private int stopExitCode = 1;

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/ThreadDumpController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/ThreadDumpController.java
@@ -11,6 +11,8 @@
 
 package com.googlecode.psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class ThreadDumpController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/WrapperInfoController.java
+++ b/core/src/main/java/com/googlecode/psiprobe/controllers/wrapper/WrapperInfoController.java
@@ -13,6 +13,8 @@ package com.googlecode.psiprobe.controllers.wrapper;
 
 import com.googlecode.psiprobe.model.wrapper.WrapperInfo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -26,6 +28,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class WrapperInfoController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/AddQueryParamTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/AddQueryParamTag.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.jsp;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 
 import java.io.IOException;
@@ -33,7 +33,7 @@ public class AddQueryParamTag extends TagSupport {
   private static final long serialVersionUID = 1L;
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
   
   /** The param. */
   private String param;

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/DurationTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/DurationTag.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.jsp;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -31,7 +31,7 @@ public class DurationTag extends TagSupport {
   private static final long serialVersionUID = 1L;
 
   /** The logger. */
-  private static final Log logger = LogFactory.getLog(DurationTag.class);
+  private static final Logger logger = LoggerFactory.getLogger(DurationTag.class);
 
   /** The value. */
   private long value;

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/ParamToggleTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/ParamToggleTag.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.jsp;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class ParamToggleTag extends TagSupport {
   private static final long serialVersionUID = 1L;
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
   
   /** The param. */
   private String param = "size";

--- a/core/src/main/java/com/googlecode/psiprobe/jsp/VolumeTag.java
+++ b/core/src/main/java/com/googlecode/psiprobe/jsp/VolumeTag.java
@@ -13,8 +13,8 @@ package com.googlecode.psiprobe.jsp;
 
 import com.googlecode.psiprobe.tools.SizeExpression;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -34,7 +34,7 @@ public class VolumeTag extends TagSupport {
   private static final long serialVersionUID = 1L;
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(getClass());
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The value. */
   private long value;

--- a/core/src/main/java/com/googlecode/psiprobe/model/DisconnectedLogDestination.java
+++ b/core/src/main/java/com/googlecode/psiprobe/model/DisconnectedLogDestination.java
@@ -20,7 +20,7 @@ import java.sql.Timestamp;
 /**
  * This class holds attributes of any other LogDestination so that LogDestination can be serialized.
  * It is generally difficult to make just any LogDestination to be serializable as they more often
- * than not are connected to underlying Log implementation that are in many cases not serializable.
+ * than not are connected to underlying Logger implementation that are in many cases not serializable.
  * 
  * @author Vlad Ilyushchenko
  * @author Mark Lewis
@@ -54,7 +54,7 @@ public class DisconnectedLogDestination implements LogDestination, Serializable 
   /** The file. */
   private final File file;
   
-  /** The log type. */
+  /** The Logger type. */
   private final String logType;
   
   /** The size. */
@@ -70,7 +70,7 @@ public class DisconnectedLogDestination implements LogDestination, Serializable 
   private final String[] validLevels;
 
   /**
-   * Instantiates a new disconnected log destination.
+   * Instantiates a new disconnected Logger destination.
    *
    * @param destination the destination
    */

--- a/core/src/main/java/com/googlecode/psiprobe/model/stats/StatsCollection.java
+++ b/core/src/main/java/com/googlecode/psiprobe/model/stats/StatsCollection.java
@@ -14,8 +14,8 @@ package com.googlecode.psiprobe.model.stats;
 import com.googlecode.psiprobe.tools.UpdateCommitLock;
 
 import com.thoughtworks.xstream.XStream;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jfree.data.xy.XYDataItem;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
@@ -45,7 +45,7 @@ import java.util.TreeMap;
 public class StatsCollection implements InitializingBean, DisposableBean, ApplicationContextAware {
 
   /** The logger. */
-  private final Log logger = LogFactory.getLog(this.getClass());
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   /** The stats data. */
   private Map<String, List<XYDataItem>> statsData = new TreeMap<String, List<XYDataItem>>();

--- a/core/src/main/java/com/googlecode/psiprobe/tools/ApplicationUtils.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/ApplicationUtils.java
@@ -29,8 +29,8 @@ import org.apache.catalina.Session;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.core.StandardWrapper;
 import org.apache.catalina.deploy.FilterDef;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.ClassUtils;
 
 import java.io.Serializable;
@@ -57,7 +57,7 @@ import javax.servlet.http.HttpSession;
 public class ApplicationUtils {
 
   /** The logger. */
-  private static final Log logger = LogFactory.getLog(ApplicationUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(ApplicationUtils.class);
 
   /**
    * Gets the application.

--- a/core/src/main/java/com/googlecode/psiprobe/tools/JmxTools.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/JmxTools.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.tools;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.MBeanAttributeInfo;
@@ -29,7 +29,7 @@ import javax.management.openmbean.CompositeData;
 public class JmxTools {
 
   /** The logger. */
-  private static final Log logger = LogFactory.getLog(JmxTools.class);
+  private static final Logger logger = LoggerFactory.getLogger(JmxTools.class);
 
   /**
    * Gets the attribute.

--- a/core/src/main/java/com/googlecode/psiprobe/tools/LogOutputStream.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/LogOutputStream.java
@@ -11,10 +11,10 @@
 
 package com.googlecode.psiprobe.tools;
 
-import org.apache.commons.logging.Log;
-
 import java.io.OutputStream;
 import java.io.PrintStream;
+
+import org.slf4j.Logger;
 
 /**
  * An {@code OutputStream} which writes to a commons-logging {@code Log} at a particular level.
@@ -41,11 +41,8 @@ public class LogOutputStream extends OutputStream {
   /** The Constant LEVEL_ERROR. */
   public static final int LEVEL_ERROR = 5;
   
-  /** The Constant LEVEL_FATAL. */
-  public static final int LEVEL_FATAL = 6;
-
   /** The log. */
-  private final Log log;
+  private final Logger log;
   
   /** The level. */
   private final int level;
@@ -61,7 +58,7 @@ public class LogOutputStream extends OutputStream {
    * @param level the level at which to write
    * @return a {@code PrintStream} that writes to the given log
    */
-  public static PrintStream createPrintStream(Log log, int level) {
+  public static PrintStream createPrintStream(Logger log, int level) {
     LogOutputStream logStream = new LogOutputStream(log, level);
     return new PrintStream(logStream, true);
   }
@@ -74,7 +71,7 @@ public class LogOutputStream extends OutputStream {
    * @param level the level at which to write
    * @throws IllegalArgumentException if {@code log} is null
    */
-  private LogOutputStream(Log log, int level) {
+  private LogOutputStream(Logger log, int level) {
     if (log == null) {
       throw new IllegalArgumentException("Log cannot be null");
     }
@@ -112,7 +109,7 @@ public class LogOutputStream extends OutputStream {
    *
    * @return the {@code Log} to which this stream writes
    */
-  public Log getLog() {
+  public Logger getLog() {
     return log;
   }
 
@@ -143,8 +140,6 @@ public class LogOutputStream extends OutputStream {
         return log.isWarnEnabled();
       case LEVEL_ERROR:
         return log.isErrorEnabled();
-      case LEVEL_FATAL:
-        return log.isFatalEnabled();
       default:
         return false;
     }
@@ -174,9 +169,6 @@ public class LogOutputStream extends OutputStream {
         break;
       case LEVEL_ERROR:
         log.error(message);
-        break;
-      case LEVEL_FATAL:
-        log.fatal(message);
         break;
       default:
         //Don't log anything

--- a/core/src/main/java/com/googlecode/psiprobe/tools/Mailer.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/Mailer.java
@@ -11,8 +11,8 @@
 
 package com.googlecode.psiprobe.tools;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -44,7 +44,7 @@ public class Mailer {
   public static final String PROPERTY_KEY_SMTP = "mail.smtp.host";
 
   /** The log. */
-  private final Log log = LogFactory.getLog(this.getClass());
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
   
   /** The from. */
   private String from;

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/DefaultAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/DefaultAccessor.java
@@ -15,8 +15,8 @@ import com.googlecode.psiprobe.model.Application;
 
 import org.apache.commons.beanutils.MethodUtils;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class DefaultAccessor.
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
 public class DefaultAccessor {
 
   /** The log. */
-  protected final Log log = LogFactory.getLog(getClass());
+  protected final Logger log = LoggerFactory.getLogger(getClass());
   
   /** The application. */
   private Application application;

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/commons/CommonsLoggerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/commons/CommonsLoggerAccessor.java
@@ -40,7 +40,7 @@ public class CommonsLoggerAccessor extends DefaultAccessor {
   /**
    * Gets the destination.
    *
-   * @param logIndex the log index
+   * @param logIndex the Logger index
    * @return the destination
    */
   public LogDestination getDestination(String logIndex) {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
@@ -22,7 +22,7 @@ import com.googlecode.psiprobe.tools.logging.log4j.Log4JLoggerAccessor;
  */
 public class GetSingleDestinationVisitor extends LoggerAccessorVisitor {
 
-  /** The log index. */
+  /** The Logger index. */
   private final String logIndex;
   
   /** The destination. */
@@ -31,7 +31,7 @@ public class GetSingleDestinationVisitor extends LoggerAccessorVisitor {
   /**
    * Instantiates a new gets the single destination visitor.
    *
-   * @param logIndex the log index
+   * @param logIndex the Logger index
    */
   public GetSingleDestinationVisitor(String logIndex) {
     this.logIndex = logIndex;

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
@@ -101,7 +101,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
   /**
    * Gets the handler.
    *
-   * @param logIndex the log index
+   * @param logIndex the Logger index
    * @return the handler
    */
   public Jdk14HandlerAccessor getHandler(String logIndex) {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
@@ -59,10 +59,10 @@ public class LogbackAppenderAccessor extends AbstractLogDestination {
   }
 
   /**
-   * Returns the log type, to distinguish logback appenders from other types like log4j appenders or
+   * Returns the Logger type, to distinguish logback appenders from other types like log4j appenders or
    * jdk handlers.
    * 
-   * @return the log type
+   * @return the Logger type
    */
   @Override
   public String getLogType() {
@@ -107,13 +107,13 @@ public class LogbackAppenderAccessor extends AbstractLogDestination {
   }
 
   /**
-   * Returns the valid log level names.
+   * Returns the valid Logger level names.
    * 
    * <p>
    * Note that Logback has no FATAL level.
    * </p>
    * 
-   * @return the valid log level names
+   * @return the valid Logger level names
    */
   @Override
   public String[] getValidLevels() {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
@@ -106,7 +106,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
   }
 
   /**
-   * Gets the log level of this logger.
+   * Gets the Logger level of this logger.
    * 
    * @return the level of this logger
    */
@@ -121,7 +121,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
   }
 
   /**
-   * Sets the log level of this logger.
+   * Sets the Logger level of this logger.
    * 
    * @param newLevelStr the name of the new level
    */

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessor.java
@@ -59,10 +59,10 @@ public class TomcatSlf4jLogbackAppenderAccessor extends AbstractLogDestination {
   }
 
   /**
-   * Returns the log type, to distinguish tomcatSlf4jLogback appenders from other types like log4j
+   * Returns the Logger type, to distinguish tomcatSlf4jLogback appenders from other types like log4j
    * appenders or jdk handlers.
    * 
-   * @return the log type
+   * @return the Logger type
    */
   @Override
   public String getLogType() {
@@ -107,13 +107,13 @@ public class TomcatSlf4jLogbackAppenderAccessor extends AbstractLogDestination {
   }
 
   /**
-   * Returns the valid log level names.
+   * Returns the valid Logger level names.
    * 
    * <p>
    * Note that Logback has no FATAL level.
    * </p>
    * 
-   * @return the valid log level names
+   * @return the valid Logger level names
    */
   @Override
   public String[] getValidLevels() {

--- a/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
+++ b/core/src/main/java/com/googlecode/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
@@ -108,7 +108,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
   }
 
   /**
-   * Gets the log level of this logger.
+   * Gets the Logger level of this logger.
    * 
    * @return the level of this logger
    */
@@ -123,7 +123,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
   }
 
   /**
-   * Sets the log level of this logger.
+   * Sets the Logger level of this logger.
    * 
    * @param newLevelStr the name of the new level
    */


### PR DESCRIPTION
Fixes #573 Error stopping/starting an app with Probe 2.4 under Tomcat 8.

org.apache.catalina.Context.getAvailable() were deprecated in Tomcat 7
and a note were added stating it will be removed in Tomcat 8. Therefore,
the java.lang.NoSuchMethodError at
org.apache.catalina.Context.getAvailable().