### PR TITLE
Maven POM Cleanup - Fixes #632

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -125,12 +125,6 @@
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
 			<scope>compile</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-collections</groupId>
@@ -196,12 +190,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
 			<scope>compile</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
 				<version>1.9.2</version>
+				<exclusions>
+					<exclusion>
+						<artifactId>commons-logging</artifactId>
+						<groupId>commons-logging</groupId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>commons-collections</groupId>
@@ -199,11 +205,6 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>2.6</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<version>1.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-modeler</groupId>
@@ -275,6 +276,12 @@
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-beans</artifactId>
 				<version>4.2.4.RELEASE</version>
+				<exclusions>
+					<exclusion>
+						<artifactId>commons-logging</artifactId>
+						<groupId>commons-logging</groupId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/tomcat70adapter/pom.xml
+++ b/tomcat70adapter/pom.xml
@@ -60,16 +60,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-modeler</groupId>
-			<artifactId>commons-modeler</artifactId>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/tomcat80adapter/pom.xml
+++ b/tomcat80adapter/pom.xml
@@ -54,16 +54,6 @@
 			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-modeler</groupId>
-			<artifactId>commons-modeler</artifactId>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/tomcat90adapter/pom.xml
+++ b/tomcat90adapter/pom.xml
@@ -54,16 +54,6 @@
 			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-modeler</groupId>
-			<artifactId>commons-modeler</artifactId>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
Fixes #632 
- Remove unnecessary dependencies from adapters
- Exclude commons-logging in parent not core