### PR TITLE
Spring fix deprecated path-type by changing to request-matcher - Fixes #634

### DIFF
--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -5,7 +5,7 @@
 		xsi:schemaLocation="http://www.springframework.org/schema/beans    http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
 		                    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 	<bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
-		<sec:filter-chain-map path-type="ant">
+		<sec:filter-chain-map request-matcher="ant">
 			<sec:filter-chain pattern="/**" filters="j2eePreAuthenticatedProcessingFilter,logoutFilter,etf,fsi"/>
 		</sec:filter-chain-map>
 	</bean>


### PR DESCRIPTION
Fixes #634 by replacing path-type with request-matcher which is further documented in xsd.