### PR TITLE
Upgraded spring security 3 to 4 and turned 'sif' back on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,17 +306,17 @@
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-config</artifactId>
-				<version>3.2.9.RELEASE</version>
+				<version>4.0.3.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-core</artifactId>
-				<version>3.2.9.RELEASE</version>
+				<version>4.0.3.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-web</artifactId>
-				<version>3.2.9.RELEASE</version>
+				<version>4.0.3.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>javainetlocator</groupId>

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -6,7 +6,7 @@
 							http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd">
 	<bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
 		<sec:filter-chain-map request-matcher="ant">
-			<sec:filter-chain pattern="/**" filters="j2eePreAuthenticatedProcessingFilter,logoutFilter,etf,fsi"/>
+			<sec:filter-chain pattern="/**" filters="sif,j2eePreAuthenticatedProcessingFilter,logoutFilter,etf,fsi"/>
 		</sec:filter-chain-map>
 	</bean>
 
@@ -18,7 +18,7 @@
 		</constructor-arg>
 	</bean>
 
-	<bean id="sif" class="org.springframework.security.web.context.HttpSessionSecurityContextRepository"/>
+	<bean id="sif" class="org.springframework.security.web.context.SecurityContextPersistenceFilter"/>
 
 	<bean id="preAuthenticatedAuthenticationProvider" class="org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider">
 		<property name="preAuthenticatedUserDetailsService" ref="preAuthenticatedUserDetailsService"/>

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -2,8 +2,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"  xmlns:sec="http://www.springframework.org/schema/security"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans    http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-		                    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+							http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd">
 	<bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
 		<sec:filter-chain-map request-matcher="ant">
 			<sec:filter-chain pattern="/**" filters="j2eePreAuthenticatedProcessingFilter,logoutFilter,etf,fsi"/>
@@ -11,11 +11,11 @@
 	</bean>
 
 	<bean id="authenticationManager" class="org.springframework.security.authentication.ProviderManager">
-		<property name="providers">
+		<constructor-arg>
 			<list>
 				<ref bean="preAuthenticatedAuthenticationProvider"/>
 			</list>
-		</property>
+		</constructor-arg>
 	</bean>
 
 	<bean id="sif" class="org.springframework.security.web.context.HttpSessionSecurityContextRepository"/>
@@ -68,29 +68,29 @@
 	</bean>
 
 	<bean id="etf" class="org.springframework.security.web.access.ExceptionTranslationFilter">
-		<property name="authenticationEntryPoint" ref="preAuthenticatedProcessingFilterEntryPoint"/>
+		<constructor-arg name="authenticationEntryPoint" ref="preAuthenticatedProcessingFilterEntryPoint"/>
 	</bean>
 
 	<bean id="httpRequestAccessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">
 		<property name="allowIfAllAbstainDecisions" value="false"/>
-		<property name="decisionVoters">
+		<constructor-arg name="decisionVoters">
 			<list>
 				<ref bean="roleVoter"/>
 			</list>
-		</property>
+		</constructor-arg>
 	</bean>
 
 	<bean id="fsi" class="org.springframework.security.web.access.intercept.FilterSecurityInterceptor">
 		<property name="authenticationManager" ref="authenticationManager"/>
 		<property name="accessDecisionManager" ref="httpRequestAccessDecisionManager"/>
 		<property name="securityMetadataSource">
-			<sec:filter-invocation-definition-source>
+			<sec:filter-security-metadata-source use-expressions="false">
 				<sec:intercept-url pattern="/adm/**"  access="ROLE_MANAGER,ROLE_MANAGER-GUI"/>
 				<sec:intercept-url pattern="/adm/restartvm.ajax" access="ROLE_POWERUSERPLUS,ROLE_MANAGER,ROLE_MANAGER-GUI"/>
 				<sec:intercept-url pattern="/sql/**"  access="ROLE_POWERUSERPLUS,ROLE_MANAGER,ROLE_MANAGER-GUI"/>
 				<sec:intercept-url pattern="/app/**"  access="ROLE_POWERUSER,ROLE_POWERUSERPLUS,ROLE_MANAGER,ROLE_MANAGER-GUI"/>
 				<sec:intercept-url pattern="/**"      access="ROLE_PROBEUSER,ROLE_POWERUSER,ROLE_POWERUSERPLUS,ROLE_MANAGER,ROLE_MANAGER-GUI"/>
-			</sec:filter-invocation-definition-source>
+			</sec:filter-security-metadata-source>
 		</property>
 	</bean>
 

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -33,7 +33,7 @@
 	</bean>
 
 	<bean id="preAuthenticatedProcessingFilterEntryPoint"
-		  class="org.springframework.security.web.authentication.Http403ForbiddenEntryPoint"/>
+		class="org.springframework.security.web.authentication.Http403ForbiddenEntryPoint"/>
 
 	<bean id="logoutFilter" class="org.springframework.security.web.authentication.logout.LogoutFilter">
 		<constructor-arg value="/"/>
@@ -53,19 +53,7 @@
 		<property name="convertAttributeToUpperCase" value="true"/>
 	</bean>
 
-	<bean id="j2eeMappableRolesRetriever" class="org.springframework.security.web.authentication.preauth.j2ee.WebXmlMappableAttributesRetriever">
-		<!-- Do we need this?
-        <property name="webXmlInputStream">
-			<bean factory-bean="webXmlResource" factory-method="getInputStream"/>
-		</property>
-        -->
-	</bean>
-
-    <!--  Now not used -->
-	<bean id="webXmlResource" class="org.springframework.web.context.support.ServletContextResource">
-		<constructor-arg ref="servletContext"/>
-		<constructor-arg value="/WEB-INF/web.xml"/>
-	</bean>
+	<bean id="j2eeMappableRolesRetriever" class="org.springframework.security.web.authentication.preauth.j2ee.WebXmlMappableAttributesRetriever" />
 
 	<bean id="etf" class="org.springframework.security.web.access.ExceptionTranslationFilter">
 		<constructor-arg name="authenticationEntryPoint" ref="preAuthenticatedProcessingFilterEntryPoint"/>
@@ -96,10 +84,6 @@
 
 	<bean id="roleVoter" class="org.springframework.security.access.vote.RoleVoter"/>
 
-	<bean id="securityContextHolderAwareRequestFilter" class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter">
-		<!-- Do we need this?
-        <property name="wrapperClass" value="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper"/>
-        -->
-	</bean>
+	<bean id="securityContextHolderAwareRequestFilter" class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter" />
 
 </beans>


### PR DESCRIPTION
Previously 'sif' bean was disabled.  Discovered it's replacement that was for spring security 3+.  Also removed previously commented out elements as no constructors existed any longer and we have been running ok for some time without those settings. 

This finalizes #449 