### PR TITLE
squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks

### DIFF
--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -325,11 +325,10 @@ public class LogResolverBean {
       Jdk14ManagerAccessor jdk14accessor = new Jdk14ManagerAccessor(cl);
       jdk14accessor.setApplication(application);
       appenders.addAll(jdk14accessor.getHandlers());
-    } catch (Throwable t) {
+    } catch (ThreadDeath t) {
       // make sure we always re-throw ThreadDeath
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("Could not resolve JDK loggers for " + applicationName, t);
     }
 
@@ -338,13 +337,12 @@ public class LogResolverBean {
       Log4JManagerAccessor log4JAccessor = new Log4JManagerAccessor(cl);
       log4JAccessor.setApplication(application);
       appenders.addAll(log4JAccessor.getAppenders());
-    } catch (Throwable t) {
+    } catch (ThreadDeath t) {
       //
       // make sure we always re-throw ThreadDeath
       //
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("Could not resolve log4j loggers for " + applicationName, t);
     }
 
@@ -353,13 +351,12 @@ public class LogResolverBean {
       LogbackFactoryAccessor logbackAccessor = new LogbackFactoryAccessor(cl);
       logbackAccessor.setApplication(application);
       appenders.addAll(logbackAccessor.getAppenders());
-    } catch (Throwable t) {
+    } catch (ThreadDeath t) {
       //
       // make sure we always re-throw ThreadDeath
       //
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("Could not resolve logback loggers for " + applicationName, t);
     }
 
@@ -369,13 +366,12 @@ public class LogResolverBean {
           new TomcatSlf4jLogbackFactoryAccessor(cl);
       tomcatSlf4jLogbackAccessor.setApplication(application);
       appenders.addAll(tomcatSlf4jLogbackAccessor.getAppenders());
-    } catch (Throwable t) {
+    } catch (ThreadDeath t) {
       //
       // make sure we always re-throw ThreadDeath
       //
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("Could not resolve tomcat-slf4j-logback loggers for " + applicationName, t);
     }
   }
@@ -487,11 +483,10 @@ public class LogResolverBean {
       if (log != null) {
         return log.getHandler(handlerIndex);
       }
-    } catch (Throwable t) {
+    } catch (ThreadDeath t) {
       // always re-throw ThreadDeath when catching Throwable
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("getJdk14LogDestination failed", t);
     }
     return null;
@@ -517,11 +512,10 @@ public class LogResolverBean {
       if (log != null) {
         return log.getAppender(appenderName);
       }
-    } catch (Throwable t) {
+    } catch(ThreadDeath t) {
       // always re-throw ThreadDeath when catching Throwable
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("getLog4JLogDestination failed", t);
     }
     return null;
@@ -547,11 +541,10 @@ public class LogResolverBean {
       if (log != null) {
         return log.getAppender(appenderName);
       }
-    } catch (Throwable t) {
+    } catch(ThreadDeath t) {
       // always re-throw ThreadDeath when catching Throwable
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("getLogbackLogDestination failed", t);
     }
     return null;
@@ -578,11 +571,10 @@ public class LogResolverBean {
       if (log != null) {
         return log.getAppender(appenderName);
       }
-    } catch (Throwable t) {
+    } catch(ThreadDeath t) {
       // always re-throw ThreadDeath when catching Throwable
-      if (t instanceof ThreadDeath) {
-        throw (ThreadDeath) t;
-      }
+      throw t;
+    } catch (Throwable t) {
       logger.debug("getTomcatSlf4jLogbackLogDestination failed", t);
     }
     return null;

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -198,13 +198,10 @@ public class ResourceResolverBean implements ResourceResolver {
           }
         }
         return false;
-      } catch (Throwable e) {
-        //
+      } catch (ThreadDeath t) {
         // make sure we always re-throw ThreadDeath
-        //
-        if (e instanceof ThreadDeath) {
-          throw (ThreadDeath) e;
-        }
+        throw (ThreadDeath) t;
+      }catch (Throwable e) {
         return false;
       }
     } finally {

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -200,7 +200,7 @@ public class ResourceResolverBean implements ResourceResolver {
         return false;
       } catch (ThreadDeath t) {
         // make sure we always re-throw ThreadDeath
-        throw (ThreadDeath) t;
+        throw t;
       }catch (Throwable e) {
         return false;
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1193
Please let me know if you have any questions.
George Kankava
Unwatch this pull request
Learn more
