### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -318,7 +318,7 @@ public class LogResolverBean {
       List<LogDestination> appenders) {
 
     String applicationName =
-        (application != null ? "application \"" + application.getName() + "\"" : "server");
+        application != null ? "application \"" + application.getName() + "\"" : "server";
 
     // check for JDK loggers
     try {
@@ -574,7 +574,7 @@ public class LogResolverBean {
       TomcatSlf4jLogbackFactoryAccessor manager = new TomcatSlf4jLogbackFactoryAccessor(cl);
       manager.setApplication(application);
       TomcatSlf4jLogbackLoggerAccessor log =
-          (root ? manager.getRootLogger() : manager.getLogger(logName));
+          root ? manager.getRootLogger() : manager.getLogger(logName);
       if (log != null) {
         return log.getAppender(appenderName);
       }

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -189,7 +189,7 @@ public class ResourceResolverBean implements ResourceResolver {
     try {
       javax.naming.Context ctx =
           (context != null) ? new InitialContext() : getGlobalNamingContext();
-      String jndiName = resolveJndiName(resourceName, (context == null));
+      String jndiName = resolveJndiName(resourceName, context == null);
       Object obj = ctx.lookup(jndiName);
       try {
         for (DatasourceAccessor accessor : datasourceMappers) {
@@ -224,7 +224,7 @@ public class ResourceResolverBean implements ResourceResolver {
     try {
       javax.naming.Context ctx =
           (context != null) ? new InitialContext() : getGlobalNamingContext();
-      String jndiName = resolveJndiName(resourceName, (context == null));
+      String jndiName = resolveJndiName(resourceName, context == null);
       Object obj = ctx.lookup(jndiName);
 
       if (obj instanceof DataSource) {

--- a/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
+++ b/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
@@ -129,9 +129,9 @@ public class VisualScoreTag extends BodyTagSupport {
 
     int redWhole = (int) Math.floor(value / blockWidth);
     int redPart = (int) Math.floor((value - redWhole * blockWidth) / unitSize);
-    int bluePart1 = (redPart > 0
+    int bluePart1 = redPart > 0
         ? Math.min((int) Math.floor(value2 / unitSize), partialBlocks - redPart)
-        : 0);
+        : 0;
     int blueWhole = (int) Math.max(0, Math.ceil(value2 / blockWidth) - (redPart > 0 ? 1 : 0));
     int bluePart2 = (int) Math.floor(
         (value2 - (blueWhole * blockWidth) - (bluePart1 * unitSize)) / unitSize);

--- a/core/src/main/java/psiprobe/tools/JmxTools.java
+++ b/core/src/main/java/psiprobe/tools/JmxTools.java
@@ -81,7 +81,7 @@ public class JmxTools {
   public static long getLongAttr(CompositeData cds, String name) {
     Object obj = cds.get(name);
     if (obj != null && obj instanceof Long) {
-      return ((Long) obj);
+      return (Long) obj;
     }
     return 0;
   }
@@ -98,7 +98,7 @@ public class JmxTools {
   public static long getLongAttr(MBeanServer mbeanServer, ObjectName objName, String attrName)
       throws Exception {
 
-    return ((Long) mbeanServer.getAttribute(objName, attrName));
+    return (Long) mbeanServer.getAttribute(objName, attrName);
   }
 
   /**
@@ -113,7 +113,7 @@ public class JmxTools {
   public static int getIntAttr(MBeanServer mbeanServer, ObjectName objName, String attrName)
       throws Exception {
 
-    return ((Integer) mbeanServer.getAttribute(objName, attrName));
+    return (Integer) mbeanServer.getAttribute(objName, attrName);
   }
 
   /**
@@ -128,7 +128,7 @@ public class JmxTools {
     Object obj = cds.get(name);
 
     if (obj != null && obj instanceof Integer) {
-      return ((Integer) obj);
+      return (Integer) obj;
     }
     return defaultValue;
   }

--- a/core/src/main/java/psiprobe/tools/Mailer.java
+++ b/core/src/main/java/psiprobe/tools/Mailer.java
@@ -280,7 +280,7 @@ public class Mailer {
       throws MessagingException {
     MimeBodyPart bodyPart = new MimeBodyPart();
     bodyPart.setText(body);
-    bodyPart.setHeader("content-type", (html ? "text/html" : "text/plain"));
+    bodyPart.setHeader("content-type", html ? "text/html" : "text/plain");
     return bodyPart;
   }
 

--- a/core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
@@ -50,8 +50,8 @@ public class CatalinaLoggerAccessor extends AbstractLogDestination {
     String date = timestamp ? new SimpleDateFormat("yyyy-MM-dd").format(new Date()) : "";
 
     File file =
-        (date != null && dir != null && prefix != null && suffix != null ? new File(dir, prefix
-            + date + suffix) : null);
+        date != null && dir != null && prefix != null && suffix != null ? new File(dir, prefix
+            + date + suffix) : null;
     if (file != null && !file.isAbsolute()) {
       return new File(System.getProperty("catalina.base"), file.getPath());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava