### PR TITLE
Add SIFT logback.xml for support of testing our SIFT logback logic

### DIFF
--- a/web/src/test/java/resources/README.md
+++ b/web/src/test/java/resources/README.md
@@ -1,0 +1,3 @@
+Misc. Tests for verification purposes.
+
+- logback.xml has SIFT appender example in it specifically for testing SIFT support with logback.  This is not used with a test directly but rather needs bundled with app and ran in container.

--- a/web/src/test/java/resources/logback.xml
+++ b/web/src/test/java/resources/logback.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE project>
+<configuration scan="true" debug="false">
+
+  <appender name="PSI-PROBE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${probe.log.path}/probe.log</File>
+    <append>true</append>
+    <encoder>
+      <charset>utf-8</charset>
+      <pattern>%d{HH:mm:ss.SSS} %-5level {%thread} [%logger{40}] %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${probe.log.path}/archive/probe-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+      <maxHistory>10</maxHistory>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>20MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+    </rollingPolicy>
+  </appender>
+
+  <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <discriminator>
+      <key>userid</key>
+      <defaultValue>unknown</defaultValue>
+    </discriminator>
+    <sift>
+      <appender name="FILE-${userid}" class="ch.qos.logback.core.FileAppender">
+        <file>user-${userid}.log</file>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+          <pattern>%d{HH:mm:ss:SSS} | %-5level | %thread | %logger{20} | %msg%n%rEx</pattern>
+        </layout>
+      </appender>
+    </sift>
+  </appender>
+
+  <logger name="org.springframework.web.context.support" level="ERROR"/>
+  <logger name="org.springframework.beans.factory.support" level="ERROR"/>
+
+  <root level="INFO">
+    <appender-ref ref="PSI-PROBE"/>
+    <appender-ref ref="SIFT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Please note that as noted in readme this is for manual usage to verify our SIFT appender logic with logback so we don't need to look elsewhere.  As I didn't see a real good place to put this, I just added it to the resources package on test side for web module.  If there might be a more appropriate location to store this, please advice and I'll move it.