### PR TITLE
Fixes #573 Error stopping/starting an app with Probe 2.4 under Tomcat 8

### DIFF
--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -33,7 +33,7 @@ public class AjaxToggleContextController extends ContextHandlerController {
 
     if (!request.getContextPath().equals(contextName) && context != null) {
       try {
-        if (context.getAvailable()) {
+        if (context.getState().isAvailable()) {
           logger.info(request.getRemoteAddr() + " requested STOP of " + contextName);
           getContainerWrapper().getTomcatContainer().stop(contextName);
         } else {


### PR DESCRIPTION
org.apache.catalina.Context.getAvailable() were deprecated in Tomcat 7
and a note were added stating it will be removed in Tomcat 8. Therefore,
the java.lang.NoSuchMethodError at
org.apache.catalina.Context.getAvailable().