### PR TITLE
FollowController always open log files with system charset encoding

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>runtime</scope>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.quartz-scheduler</groupId>

--- a/core/src/main/java/psiprobe/controllers/logs/FollowController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/FollowController.java
@@ -57,7 +57,12 @@ public class FollowController extends LogHandlerController {
 
       BackwardsFileStream bfs = new BackwardsFileStream(file, currentLength);
       try {
-        BackwardsLineReader br = new BackwardsLineReader(bfs);
+        BackwardsLineReader br;
+        if (logDest.getEncoding() != null) {
+          br = new BackwardsLineReader(bfs, logDest.getEncoding());
+        } else {
+          br = new BackwardsLineReader(bfs);
+        }
         long readSize = 0;
         long totalReadSize = currentLength - lastKnownLength;
         String line;

--- a/core/src/main/java/psiprobe/model/DisconnectedLogDestination.java
+++ b/core/src/main/java/psiprobe/model/DisconnectedLogDestination.java
@@ -68,6 +68,9 @@ public class DisconnectedLogDestination implements LogDestination, Serializable 
   
   /** The valid levels. */
   private final String[] validLevels;
+  
+  /** The file encoding name. */
+  private final String encoding;
 
   /**
    * Instantiates a new disconnected log destination.
@@ -88,6 +91,7 @@ public class DisconnectedLogDestination implements LogDestination, Serializable 
     this.lastModified = destination.getLastModified();
     this.level = destination.getLevel();
     this.validLevels = destination.getValidLevels();
+    this.encoding = destination.getEncoding();
   }
 
   @Override
@@ -155,4 +159,8 @@ public class DisconnectedLogDestination implements LogDestination, Serializable 
     return validLevels;
   }
 
+  @Override
+  public String getEncoding() {
+    return encoding;
+  }
 }

--- a/core/src/main/java/psiprobe/tools/logging/AbstractLogDestination.java
+++ b/core/src/main/java/psiprobe/tools/logging/AbstractLogDestination.java
@@ -78,4 +78,8 @@ public abstract class AbstractLogDestination extends DefaultAccessor implements 
     return null;
   }
 
+  @Override
+  public String getEncoding() {
+    return null;
+  }
 }

--- a/core/src/main/java/psiprobe/tools/logging/LogDestination.java
+++ b/core/src/main/java/psiprobe/tools/logging/LogDestination.java
@@ -115,4 +115,10 @@ public interface LogDestination {
    */
   String[] getValidLevels();
 
+  /**
+   * Gets the encoding of the file.
+   * 
+   * @return the encoding name
+   */
+  String getEncoding();
 }

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
@@ -13,6 +13,9 @@ package psiprobe.tools.logging.logback;
 
 import java.io.File;
 
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import psiprobe.tools.logging.AbstractLogDestination;
 
 /**
@@ -94,6 +97,21 @@ public class LogbackAppenderAccessor extends AbstractLogDestination {
   public File getFile() {
     String fileName = (String) getProperty(getTarget(), "file", null);
     return fileName != null ? new File(fileName) : getStdoutFile();
+  }
+  
+  public String getEncoding() {
+    if (getTarget() instanceof OutputStreamAppender) {
+      OutputStreamAppender<?> appender = (OutputStreamAppender<?>) getTarget();
+      Encoder<?> encoder = appender.getEncoder();
+      if (encoder instanceof LayoutWrappingEncoder) {
+        LayoutWrappingEncoder<?> base = (LayoutWrappingEncoder<?>) encoder;
+        if (base.getCharset() != null) {
+          return base.getCharset().name();
+        }
+        return null;
+      }
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Fixes #644.

This actually will only work for logback loggers. We could create one issue for each logging API.