### PR TITLE
Must filter logback resource due to moving it's location

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -112,6 +112,14 @@
 				<configuration>
 					<webResources>
 						<resource>
+							<directory>${project.basedir}/src/main/resources</directory>
+							<includes>
+								<include>logback.xml</include>
+							</includes>
+							<targetPath>WEB-INF/classes</targetPath>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
 							<directory>${project.basedir}/src/main/webapp</directory>
 							<filtering>true</filtering>
 						</resource>


### PR DESCRIPTION
After logback.xml was moved into standard location, the filtering necessary to indicate where logs land no longer was activated by default.  Adjusted the pom so this picks up properly.  Now logging is back to normal.