### PR TITLE
Replaces Commons Logging usage with Slf4j - Fixes #613

### DIFF
--- a/core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -406,7 +406,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
   }
 
   @Override
-  public org.apache.juli.logging.Log getLogger(Context context) {
+  public Object getLogger(Context context) {
     return context.getLogger();
   }
 

--- a/core/src/main/java/psiprobe/ProbeServlet.java
+++ b/core/src/main/java/psiprobe/ProbeServlet.java
@@ -13,6 +13,8 @@ package psiprobe;
 
 import org.apache.catalina.ContainerServlet;
 import org.apache.catalina.Wrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.DispatcherServlet;
 
 import psiprobe.beans.ContainerWrapperBean;
@@ -34,6 +36,9 @@ public class ProbeServlet extends DispatcherServlet implements ContainerServlet 
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = 1L;
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The wrapper. */
   private Wrapper wrapper;

--- a/core/src/main/java/psiprobe/controllers/ContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/ContextHandlerController.java
@@ -12,6 +12,8 @@
 package psiprobe.controllers;
 
 import org.apache.catalina.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -25,6 +27,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Mark Lewis
  */
 public abstract class ContextHandlerController extends TomcatContainerController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/RenderChartController.java
+++ b/core/src/main/java/psiprobe/controllers/RenderChartController.java
@@ -20,6 +20,8 @@ import org.jfree.chart.renderer.xy.XYAreaRenderer;
 import org.jfree.chart.renderer.xy.XYLine3DRenderer;
 import org.jfree.data.xy.DefaultTableXYDataset;
 import org.jfree.ui.RectangleInsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -54,6 +56,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class RenderChartController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The stats collection. */
   private StatsCollection statsCollection;

--- a/core/src/main/java/psiprobe/controllers/TomcatContainerController.java
+++ b/core/src/main/java/psiprobe/controllers/TomcatContainerController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.mvc.AbstractController;
 
 import psiprobe.beans.ContainerWrapperBean;
@@ -21,6 +23,9 @@ import psiprobe.beans.ContainerWrapperBean;
  * @author Vlad Ilyushchenko
  */
 public abstract class TomcatContainerController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The container wrapper. */
   private ContainerWrapperBean containerWrapper;

--- a/core/src/main/java/psiprobe/controllers/WhoisController.java
+++ b/core/src/main/java/psiprobe/controllers/WhoisController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -35,6 +37,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class WhoisController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The lookup timeout. */
   private long lookupTimeout = 5;

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -38,7 +38,7 @@ public class AjaxReloadContextController extends ContextHandlerController {
       } catch (ThreadDeath e) {
           throw e;
       } catch (Throwable e) {
-        logger.error(e);
+        logger.error("Error during ajax request to RELOAD of " + contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -43,7 +43,7 @@ public class AjaxToggleContextController extends ContextHandlerController {
       } catch (ThreadDeath e) {
           throw e;
       } catch (Throwable e) {
-        logger.error(e);
+        logger.error("Error during ajax request to START/STOP of " + contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/psiprobe/controllers/apps/NoSelfContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/NoSelfContextHandlerController.java
@@ -63,7 +63,7 @@ public abstract class NoSelfContextHandlerController extends ContextHandlerContr
       executeAction(contextName);
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());
-      logger.error(e);
+      logger.error("Error during invocation", e);
       return new ModelAndView(new InternalResourceView(getViewName()));
     }
     return new ModelAndView(new RedirectView(request.getContextPath() + getViewName()

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -63,7 +63,7 @@ public class UndeployContextController extends ContextHandlerController {
 
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());
-      logger.error(e);
+      logger.error("Error during undeploy of " + contextName, e);
       return new ModelAndView(new InternalResourceView(getFailureViewName() == null ? getViewName()
           : getFailureViewName()));
     }

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -81,7 +81,7 @@ public class UploadWarController extends TomcatContainerController {
           }
         }
       } catch (Exception e) {
-        logger.fatal("Could not process file upload", e);
+        logger.error("Could not process file upload", e);
         request.setAttribute(
             "errorMessage",
             getMessageSourceAccessor().getMessage("probe.src.deploy.war.uploadfailure",

--- a/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.sql;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -32,6 +34,9 @@ import javax.servlet.http.HttpSession;
  */
 public class CachedRecordSetController extends ParameterizableViewController {
   
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
+
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,
       HttpServletResponse response) throws Exception {

--- a/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.sql;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -29,6 +31,9 @@ import javax.servlet.http.HttpSession;
  * @author Andy Shapoval
  */
 public class QueryHistoryItemController extends AbstractController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
+++ b/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.system;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -25,6 +27,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class AdviseGarbageCollectionController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The replace pattern. */
   private String replacePattern;

--- a/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.threads;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
@@ -29,6 +31,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class GetClassLoaderUrlsController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class RestartJvmController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class StopJvmController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   /** The stop exit code. */
   private int stopExitCode = 1;

--- a/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -24,6 +26,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class ThreadDumpController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.wrapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -26,6 +28,9 @@ import javax.servlet.http.HttpServletResponse;
  * @author Vlad Ilyushchenko
  */
 public class WrapperInfoController extends ParameterizableViewController {
+
+  /** The logger. */
+  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,


### PR DESCRIPTION
Some loggers atributes were added in classes that don't use it. The
reason is to prevent usage of Spring super classes protected logger
atribute.

@hazendaz can you check if the line endings problem is occurring?