### PR TITLE
Reverts fd71e53 Disable secure-cookie until issues with spring can be determined under http usage

### DIFF
--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -102,9 +102,13 @@
 
 	<session-config>
 		<session-timeout>15</session-timeout>
+		<!-- Disable secure cookie until http session issues can be resolved. While tomcat
+		will handle this normally with http, spring has been shown to continually create new
+		sessions.  This may not be related to spring security but rather spring web mvc.
 		<cookie-config>
 			<secure>true</secure>
 		</cookie-config>
+		-->
 	</session-config>
 
 	<!-- no access error -->


### PR DESCRIPTION
Reverts fd71e53be09084565f30bb9b6354fa6fd1c3c7d1

Addresses issue caused by #594 with tomcat handling of secure cookie and usage of spring in regardes to http processing.  While we ultimately want this, rather than full revert, this is a comment with description that issue is created.