### PR TITLE
Change cookie tracking-mode to COOKIE so it's not in the URL

### DIFF
--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -109,6 +109,7 @@
 			<secure>true</secure>
 		</cookie-config>
 		-->
+		<tracking-mode>COOKIE</tracking-mode>
 	</session-config>
 
 	<!-- no access error -->


### PR DESCRIPTION
Default JESSIONID will show in URL.  This setting for servlet 3.0+ stops presenting the JSESSIONID in the URL.  This is considered a security fix.