### PR TITLE
Remove wrapped method calls to simply get logger out of original passed context

### DIFF
--- a/core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -405,11 +405,6 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
   }
 
   @Override
-  public Object getLogger(Context context) {
-    return context.getLogger();
-  }
-
-  @Override
   public boolean getAvailable(Context context) {
     return context.getState().isAvailable();
   }

--- a/core/src/main/java/psiprobe/TomcatContainer.java
+++ b/core/src/main/java/psiprobe/TomcatContainer.java
@@ -177,14 +177,6 @@ public interface TomcatContainer {
   void discardWorkDir(Context context);
 
   /**
-   * Gets the logger.
-   *
-   * @param context the context
-   * @return the logger
-   */
-  Object getLogger(Context context);
-
-  /**
    * Gets the host name.
    *
    * @return the host name

--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -269,7 +269,7 @@ public class LogResolverBean {
     ClassLoader cl = ctx.getLoader().getClassLoader();
 
     try {
-      Object contextLogger = getContainerWrapper().getTomcatContainer().getLogger(ctx);
+      Object contextLogger = ctx.getLogger();
       if (contextLogger != null) {
         if (contextLogger.getClass().getName().startsWith("org.apache.commons.logging")) {
           CommonsLoggerAccessor commonsAccessor = new CommonsLoggerAccessor();
@@ -413,7 +413,7 @@ public class LogResolverBean {
    * @return the catalina log destination
    */
   private LogDestination getCatalinaLogDestination(Context ctx, Application application) {
-    Object log = getContainerWrapper().getTomcatContainer().getLogger(ctx);
+    Object log = ctx.getLogger();
     if (log != null) {
       CatalinaLoggerAccessor logAccessor = new CatalinaLoggerAccessor();
       logAccessor.setTarget(log);
@@ -436,7 +436,7 @@ public class LogResolverBean {
   private LogDestination getCommonsLogDestination(Context ctx, Application application,
       String logIndex) {
 
-    Object contextLogger = getContainerWrapper().getTomcatContainer().getLogger(ctx);
+    Object contextLogger = ctx.getLogger();
     CommonsLoggerAccessor commonsAccessor = new CommonsLoggerAccessor();
     commonsAccessor.setTarget(contextLogger);
     commonsAccessor.setApplication(application);


### PR DESCRIPTION
getContainerWrapper().getTomcatContainer().getLogger(context) does
nothing more than context.getLogger().  It's cleaner to just grab logger
directly.  In this case, logger is treated as Object in each case as
usage within method expects Object so the logic there stays as-is.

This was likely a legacy usage in older tomcats which changed over time to no longer be tied to tomcat directly.