### PR TITLE
Ensure we log all exceptions and use {} instead of string concat

### DIFF
--- a/core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -79,7 +79,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
         deployerOName =
             new ObjectName(host.getParent().getName() + ":type=Deployer,host=" + host.getName());
       } catch (MalformedObjectNameException e) {
-        // do nothing here
+        logger.trace("", e);
       }
       host.getPipeline().addValve(valve);
       mbeanServer = Registry.getRegistry(null, null).getMBeanServer();
@@ -170,7 +170,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
       try {
         stop(name);
       } catch (Exception e) {
-        logger.info("Stopping " + name + " threw this exception:", e);
+        logger.info("Stopping '{}' threw this exception:", name, e);
       }
 
       File appDir;
@@ -182,12 +182,12 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
         appDir = docBase;
       }
 
-      logger.debug("Deleting " + appDir.getAbsolutePath());
+      logger.debug("Deleting '{}'", appDir.getAbsolutePath());
       Utils.delete(appDir);
 
       String warFilename = formatContextFilename(name);
       File warFile = new File(getAppBase(), warFilename + ".war");
-      logger.debug("Deleting " + warFile.getAbsolutePath());
+      logger.debug("Deleting '{}'", warFile.getAbsolutePath());
       Utils.delete(warFile);
 
       File configFile = getConfigFile(ctx);
@@ -271,11 +271,11 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
   public void discardWorkDir(Context context) {
     if (context instanceof StandardContext) {
       StandardContext standardContext = (StandardContext) context;
-      logger.info("Discarding " + standardContext.getWorkPath());
+      logger.info("Discarding '{}'", standardContext.getWorkPath());
       Utils.delete(new File(standardContext.getWorkPath(), "org"));
     } else {
-      logger.error("context " + context.getName() + " is not an instance of "
-          + context.getClass().getName() + ", expected StandardContext");
+      logger.error("context '{}' is not an instance of '{}', expected StandardContext",
+              context.getName(), context.getClass().getName());
     }
   }
 
@@ -292,7 +292,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
           createJspCompilationContext(jspName, opt, sctx, jrctx, null);
       servletName = jcctx.getServletJavaFileName();
     } else {
-      logger.error("Context " + context.getName() + " does not have \"jsp\" servlet");
+      logger.error("Context '{}' does not have 'JSP' servlet", context.getName());
     }
     return servletName;
   }
@@ -327,15 +327,15 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
                     compiler.compile();
                     item.setState(Item.STATE_READY);
                     item.setException(null);
-                    logger.info("Compiled " + name + ": OK");
+                    logger.info("Compiled '{}': OK", name);
                   } catch (Exception e) {
                     item.setState(Item.STATE_FAILED);
                     item.setException(e);
-                    logger.info("Compiled " + name + ": FAILED", e);
+                    logger.info("Compiled '{}': FAILED", name, e);
                   }
                   item.setCompileTime(System.currentTimeMillis() - time);
                 } else {
-                  logger.error(name + " is not on the summary list, ignored");
+                  logger.error("{} is not on the summary list, ignored", name);
                 }
               } finally {
                 ClassUtils.overrideThreadContextClassLoader(prevCl);
@@ -346,10 +346,10 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
           }
         }
       } else {
-        logger.error("summary is null for " + context.getName() + ", request ignored");
+        logger.error("summary is null for '{}', request ignored", context.getName());
       }
     } else {
-      logger.error("Context " + context.getName() + " does not have \"jsp\" servlet");
+      logger.error("Context '{}' does not have 'JSP' servlet", context.getName());
     }
   }
 
@@ -400,7 +400,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
 
       summary.setItems(hashMap);
     } else {
-      logger.error("Context " + context.getName() + " does not have \"jsp\" servlet");
+      logger.error("Context '{}' does not have 'JSP' servlet", context.getName());
     }
   }
 
@@ -419,7 +419,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
           return new File(configUri.getPath());
         }
       } catch (URISyntaxException ex) {
-        logger.error("Could not convert URL to URI: " + configUrl, ex);
+        logger.error("Could not convert URL to URI: '{}'", configUrl, ex);
       }
     }
     return null;
@@ -477,7 +477,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
           isJsp = name.endsWith(".jsp") || name.endsWith(".jspx")
               || opt.getJspConfig().isJspPage(name);
         } catch (JasperException e) {
-          logger.info("isJspPage() thrown an error for " + name, e);
+          logger.info("isJspPage() thrown an error for '{}'", name, e);
         }
 
         if (isJsp) {
@@ -515,11 +515,11 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
                   item.setException(null);
                 }
               }
-              logger.info("Compiled " + name + ": OK");
+              logger.info("Compiled '{}': OK", name);
             } catch (Exception e) {
               item.setState(Item.STATE_FAILED);
               item.setException(e);
-              logger.info("Compiled " + name + ": FAILED", e);
+              logger.info("Compiled '{}': FAILED", name, e);
             }
             if (compile) {
               item.setCompileTime(System.currentTimeMillis() - time);
@@ -534,7 +534,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
         }
       }
     } else {
-      logger.debug("getResourcePaths() is null for " + jspName + ". Empty dir? Or Tomcat bug?");
+      logger.debug("getResourcePaths() is null for '{}'. Empty dir? Or Tomcat bug?", jspName);
     }
   }
 

--- a/core/src/main/java/psiprobe/Utils.java
+++ b/core/src/main/java/psiprobe/Utils.java
@@ -142,10 +142,10 @@ public class Utils {
         }
       }
       if (!file.delete()) {
-        logger.debug("Cannot delete " + file.getAbsolutePath());
+        logger.debug("Cannot delete '{}'", file.getAbsolutePath());
       }
     } else {
-      logger.debug(file + " does not exist");
+      logger.debug("'{}' does not exist", file);
     }
   }
 
@@ -161,7 +161,7 @@ public class Utils {
       try {
         return Integer.parseInt(num);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
     return defaultValue;
@@ -192,6 +192,7 @@ public class Utils {
       }
       return Integer.parseInt(num, 16);
     } catch (NumberFormatException e) {
+      logger.trace("", e);
       return defaultValue;
     }
   }
@@ -208,7 +209,7 @@ public class Utils {
       try {
         return Long.parseLong(num);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
     return defaultValue;
@@ -237,7 +238,7 @@ public class Utils {
       try {
         return Float.parseFloat(num);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
     return defaultValue;
@@ -353,7 +354,8 @@ public class Utils {
             rangeStart = 0;
           }
         } catch (NumberFormatException e) {
-          // ignore the exception, keep rangeStart unchanged
+          // keep rangeStart unchanged
+          logger.trace("", e);
         }
 
         if (rangeSep < pureRange.length() - 1) {
@@ -363,7 +365,7 @@ public class Utils {
               rangeFinish = fileSize - 1;
             }
           } catch (NumberFormatException e) {
-            // ignore the exception
+            logger.trace("", e);
           }
         }
       }
@@ -583,6 +585,7 @@ public class Utils {
       Set<ObjectInstance> threading = mbeanServer.queryMBeans(threadingOName, null);
       return threading != null && !threading.isEmpty();
     } catch (MalformedObjectNameException e) {
+      logger.trace("", e);
       return false;
     }
   }

--- a/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
@@ -18,6 +18,9 @@ import psiprobe.model.DataSourceInfo;
 
 import java.lang.reflect.Field;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class BoneCpDatasourceAccessor.
  *
@@ -25,6 +28,9 @@ import java.lang.reflect.Field;
  * @author Mark Lewis
  */
 public class BoneCpDatasourceAccessor implements DatasourceAccessor {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(BoneCpDatasourceAccessor.class);
 
   @Override
   public DataSourceInfo getInfo(final Object resource) throws Exception {
@@ -35,6 +41,7 @@ public class BoneCpDatasourceAccessor implements DatasourceAccessor {
       try {
         pool = source.getPool();
       } catch (NoSuchMethodError ex) {
+        logger.trace("", ex);
         // This is an older version of BoneCP (pre-0.8.0)
         final Field poolField = BoneCPDataSource.class.getDeclaredField("pool");
         poolField.setAccessible(true);

--- a/core/src/main/java/psiprobe/beans/ContainerListenerBean.java
+++ b/core/src/main/java/psiprobe/beans/ContainerListenerBean.java
@@ -248,7 +248,7 @@ public class ContainerListenerBean implements NotificationListener {
           threadPools.add(threadPool);
         }
       } catch (InstanceNotFoundException e) {
-        logger.error("Failed to query entire thread pool " + threadPoolObjectName);
+        logger.error("Failed to query entire thread pool {}", threadPoolObjectName);
         logger.debug("  Stack trace:", e);
       }
     }
@@ -308,6 +308,7 @@ public class ContainerListenerBean implements NotificationListener {
                 rp.setRemoteAddrLocale(InetAddressLocator.getLocale(InetAddress.getByName(
                     remoteAddr).getAddress()));
               } catch (RuntimeOperationsException ex) {
+                logger.trace("", ex);
                 /*
                  * if it's not available for this request processor, then it's not available for any
                  * request processor in this thread pool
@@ -338,7 +339,7 @@ public class ContainerListenerBean implements NotificationListener {
               }
               connector.addRequestProcessor(rp);
             } catch (InstanceNotFoundException e) {
-              logger.info("Failed to query RequestProcessor " + wrkName);
+              logger.info("Failed to query RequestProcessor {}", wrkName);
               logger.debug("  Stack trace:", e);
             }
           }
@@ -346,7 +347,7 @@ public class ContainerListenerBean implements NotificationListener {
 
         connectors.add(connector);
       } catch (InstanceNotFoundException e) {
-        logger.error("Failed to query entire thread pool " + threadPoolObjectName);
+        logger.error("Failed to query entire thread pool {}", threadPoolObjectName);
         logger.debug("  Stack trace:", e);
       }
     }

--- a/core/src/main/java/psiprobe/beans/ContainerWrapperBean.java
+++ b/core/src/main/java/psiprobe/beans/ContainerWrapperBean.java
@@ -88,28 +88,25 @@ public class ContainerWrapperBean {
         if (tomcatContainer == null) {
 
           String serverInfo = ServerInfo.getServerInfo();
-          logger.info("Server info: " + serverInfo);
+          logger.info("Server info: {}", serverInfo);
           for (String className : adapterClasses) {
             try {
               Object obj = Class.forName(className).newInstance();
-              logger.debug("Testing container adapter: " + className);
+              logger.debug("Testing container adapter: {}", className);
               if (obj instanceof TomcatContainer) {
                 if (forceFirstAdapter || ((TomcatContainer) obj).canBoundTo(serverInfo)) {
-                  logger.info("Using " + className);
+                  logger.info("Using {}", className);
                   tomcatContainer = (TomcatContainer) obj;
                   tomcatContainer.setWrapper(wrapper);
                   break;
                 }
-                logger.debug("Cannot bind " + className + " to " + serverInfo);
+                logger.debug("Cannot bind {} to {}", className, serverInfo);
               } else {
-                logger.error(className + " does not implement " + TomcatContainer.class.getName());
+                logger.error("{} does not implement {}", className, TomcatContainer.class.getName());
               }
             } catch (Exception e) {
-              if (logger.isDebugEnabled()) {
-                logger.debug("Failed to load " + className, e);
-              } else {
-                logger.info("Failed to load " + className);
-              }
+              logger.debug("", e);
+              logger.info("Failed to load {}", className);
             }
           }
 

--- a/core/src/main/java/psiprobe/beans/JBossResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/JBossResourceResolverBean.java
@@ -171,11 +171,12 @@ public class JBossResourceResolverBean implements ResourceResolver {
           server.invoke(poolOName, "start", null, null);
           return true;
         } catch (Exception e) {
-          logger.error("Could not reset resource \"" + resourceName + "\"", e);
+          logger.error("Could not reset resource '{}'", resourceName, e);
         }
       }
       return false;
     } catch (MalformedObjectNameException e) {
+      logger.trace("", e);
       throw new NamingException("Resource name: \"" + resourceName
           + "\" makes a malformed ObjectName");
     }

--- a/core/src/main/java/psiprobe/beans/JvmMemoryInfoAccessorBean.java
+++ b/core/src/main/java/psiprobe/beans/JvmMemoryInfoAccessorBean.java
@@ -73,7 +73,7 @@ public class JvmMemoryInfoAccessorBean {
         memoryPool.setInit(JmxTools.getLongAttr(cd, "init"));
         memoryPool.setCommitted(JmxTools.getLongAttr(cd, "committed"));
       } else {
-        logger.error("Oops, JVM problem? " + objName.toString() + " \"Usage\" attribute is NULL!");
+        logger.error("Oops, JVM problem? {} 'Usage' attribute is NULL!", objName);
       }
 
       totalInit += memoryPool.getInit();

--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -284,8 +284,8 @@ public class LogResolverBean {
         }
       }
     } catch (Exception e) {
-      logger.error("Could not interrogate context logger for " + ctx.getName()
-          + ". Enable debug logging to see the trace stack");
+      logger.error("Could not interrogate context logger for {}. Enable debug logging to see the trace stack",
+              ctx.getName());
       logger.debug("  Stack trace:", e);
     }
 
@@ -294,8 +294,8 @@ public class LogResolverBean {
       try {
         interrogateClassLoader(cl, application, allAppenders);
       } catch (Exception e) {
-        logger.error("Could not interrogate classloader loggers for " + ctx.getName()
-            + ". Enable debug logging to see the trace stack");
+        logger.error("Could not interrogate classloader loggers for {}. Enable debug logging to see the trace stack",
+                ctx.getName());
         logger.debug("  Stack trace:", e);
       } finally {
         if (prevCl != null) {
@@ -324,7 +324,7 @@ public class LogResolverBean {
       jdk14accessor.setApplication(application);
       appenders.addAll(jdk14accessor.getHandlers());
     } catch (Exception e) {
-      logger.debug("Could not resolve JDK loggers for '{}' {}", applicationName, e);
+      logger.debug("Could not resolve JDK loggers for '{}'", applicationName, e);
     }
 
     // check for Log4J loggers
@@ -333,7 +333,7 @@ public class LogResolverBean {
       log4JAccessor.setApplication(application);
       appenders.addAll(log4JAccessor.getAppenders());
     } catch (Exception e) {
-      logger.debug("Could not resolve log4j loggers for '{}' {}", applicationName, e);
+      logger.debug("Could not resolve log4j loggers for '{}'", applicationName, e);
     }
 
     // check for Logback loggers
@@ -342,7 +342,7 @@ public class LogResolverBean {
       logbackAccessor.setApplication(application);
       appenders.addAll(logbackAccessor.getAppenders());
     } catch (Exception e) {
-      logger.debug("Could not resolve logback loggers for '{}' {}", applicationName, e);
+      logger.debug("Could not resolve logback loggers for '{}'", applicationName, e);
     }
 
     // check for Logback loggers for tomcat-slf4j-logback
@@ -352,7 +352,7 @@ public class LogResolverBean {
       tomcatSlf4jLogbackAccessor.setApplication(application);
       appenders.addAll(tomcatSlf4jLogbackAccessor.getAppenders());
     } catch (Exception e) {
-      logger.debug("Could not resolve tomcat-slf4j-logback loggers for '{}' {}", applicationName, e);
+      logger.debug("Could not resolve tomcat-slf4j-logback loggers for '{}'", applicationName, e);
     }
   }
 

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -72,7 +72,7 @@ public class ResourceResolverBean implements ResourceResolver {
         for (ObjectName objectName : dsNames) {
           ApplicationResource resource = new ApplicationResource();
 
-          logger.info("reading resource: " + objectName);
+          logger.info("reading resource: {}", objectName);
           resource.setName(getStringAttribute(server, objectName, "name"));
           resource.setType(getStringAttribute(server, objectName, "type"));
           resource.setScope(getStringAttribute(server, objectName, "scope"));
@@ -99,7 +99,7 @@ public class ResourceResolverBean implements ResourceResolver {
     boolean contextAvailable = containerWrapper.getTomcatContainer().getAvailable(context);
     if (contextAvailable) {
 
-      logger.info("Reading CONTEXT " + context.getName());
+      logger.info("Reading CONTEXT {}", context.getName());
 
       boolean contextBound = false;
 
@@ -158,7 +158,7 @@ public class ResourceResolverBean implements ResourceResolver {
       } catch (Exception e) {
         resource.setLookedUp(false);
         dataSourceInfo = null;
-        logger.error("Failed to lookup: " + resource.getName(), e);
+        logger.error("Failed to lookup: '{}'", resource.getName(), e);
       }
     } else {
       resource.setLookedUp(false);
@@ -197,6 +197,7 @@ public class ResourceResolverBean implements ResourceResolver {
         }
         return false;
       } catch (Exception e) {
+        logger.trace("", e);
         return false;
       }
     } finally {
@@ -295,7 +296,7 @@ public class ResourceResolverBean implements ResourceResolver {
     try {
       return (String) server.getAttribute(objectName, attributeName);
     } catch (Exception e) {
-      logger.error("Error getting attribute '" + attributeName + "' from '" + objectName + "'", e);
+      logger.error("Error getting attribute '{}' from '{}'", attributeName, objectName, e);
       return null;
     }
   }

--- a/core/src/main/java/psiprobe/beans/RuntimeInfoAccessorBean.java
+++ b/core/src/main/java/psiprobe/beans/RuntimeInfoAccessorBean.java
@@ -80,6 +80,7 @@ public class RuntimeInfoAccessorBean {
       return ri;
     } catch (Exception e) {
       logger.debug("OS information is unavailable");
+      logger.trace("", e);
       return null;
     }
   }

--- a/core/src/main/java/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
@@ -149,7 +149,7 @@ public class AppStatsCollectorBean extends AbstractStatsCollectorBean implements
         buildAbsoluteStats("total.avg_proc_time", participatingAppCount == 0 ? 0 : totalAvgProcTime
             / participatingAppCount, currentTime);
       }
-      logger.debug("app stats collected in " + (System.currentTimeMillis() - currentTime) + "ms.");
+      logger.debug("app stats collected in {}ms", (System.currentTimeMillis() - currentTime));
     }
   }
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
@@ -67,12 +67,11 @@ public class DatasourceStatsCollectorBean extends AbstractStatsCollectorBean {
         DataSourceInfo dsi = ds.getDataSourceInfo();
         int numEstablished = dsi.getEstablishedConnections();
         int numBusy = dsi.getBusyConnections();
-        logger.trace("Collecting stats for datasource: " + name);
+        logger.trace("Collecting stats for datasource: {}", name);
         buildAbsoluteStats(PREFIX_ESTABLISHED + name, numEstablished, currentTime);
         buildAbsoluteStats(PREFIX_BUSY + name, numBusy, currentTime);
       }
-      logger.debug("datasource stats collected in " + (System.currentTimeMillis() - currentTime)
-          + "ms");
+      logger.debug("datasource stats collected in {}ms", (System.currentTimeMillis() - currentTime));
     }
   }
 

--- a/core/src/main/java/psiprobe/beans/stats/listeners/ThresholdListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/ThresholdListener.java
@@ -133,14 +133,15 @@ public abstract class ThresholdListener extends AbstractStatsCollectionListener 
   protected long getThreshold(String name) {
     String threshold = getPropertyValue(name, "threshold");
     if (threshold == null && !isSeriesDisabled(name)) {
-      logger.info("Required property " + getPropertyKey(name, "threshold")
-          + " is not defined or inherited.  Disabling listener for \"" + name + "\" series.");
+      logger.info("Required property '{}' is not defined or inherited.  Disabling listener for '{}' series",
+              getPropertyKey(name, "threshold"), name);
       setSeriesDisabled(name, true);
       return DEFAULT_THRESHOLD;
     }
     try {
       return SizeExpression.parse(threshold);
     } catch (NumberFormatException ex) {
+      logger.trace("", ex);
       return DEFAULT_THRESHOLD;
     }
   }

--- a/core/src/main/java/psiprobe/controllers/DecoratorController.java
+++ b/core/src/main/java/psiprobe/controllers/DecoratorController.java
@@ -62,6 +62,7 @@ public class DecoratorController extends ParameterizableViewController {
       request.setAttribute("hostname", InetAddress.getLocalHost().getHostName());
     } catch (UnknownHostException e) {
       request.setAttribute("hostname", "unknown");
+      logger.trace("", e);
     }
 
     Properties version = (Properties) getApplicationContext().getBean("version");

--- a/core/src/main/java/psiprobe/controllers/RenderChartController.java
+++ b/core/src/main/java/psiprobe/controllers/RenderChartController.java
@@ -138,8 +138,8 @@ public class RenderChartController extends AbstractController {
       if (series instanceof SeriesProvider) {
         ((SeriesProvider) series).populate(ds, statsCollection, request);
       } else {
-        logger.error("SeriesProvider \"" + provider + "\" does not implement "
-            + SeriesProvider.class);
+        logger.error("SeriesProvider '{}' does not implement '{}'", provider,
+            SeriesProvider.class);
       }
 
     }

--- a/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
+++ b/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
@@ -116,6 +116,7 @@ public class TomcatAvailabilityController extends TomcatContainerController {
       tomcatTestReport.setMemoryTest(TomcatTestReport.TEST_PASSED);
     } catch (IOException e) {
       tomcatTestReport.setMemoryTest(TomcatTestReport.TEST_FAILED);
+      logger.trace("", e);
     }
 
     // try to open some files
@@ -135,12 +136,13 @@ public class TomcatAvailabilityController extends TomcatContainerController {
       tomcatTestReport.setFileTest(TomcatTestReport.TEST_PASSED);
     } catch (IOException e) {
       tomcatTestReport.setFileTest(TomcatTestReport.TEST_FAILED);
+      logger.trace("", e);
     } finally {
       for (FileOutputStream fileStream : fileStreams) {
         try {
           fileStream.close();
         } catch (IOException e) {
-          //ignore
+          logger.trace("", e);
         }
       }
       for (File file : files) {

--- a/core/src/main/java/psiprobe/controllers/WhoisController.java
+++ b/core/src/main/java/psiprobe/controllers/WhoisController.java
@@ -119,6 +119,7 @@ public class WhoisController extends ParameterizableViewController {
       wh = Whois.lookup(getDefaultServer(), getDefaultPort(), ipAddress, getLookupTimeout());
     } catch (IOException e) {
       timeout = true;
+      logger.trace("", e);
     }
 
     if (wh != null) {
@@ -140,7 +141,8 @@ public class WhoisController extends ParameterizableViewController {
       try {
         reverseName = InetAddress.getByName(ipAddress).getCanonicalHostName();
       } catch (UnknownHostException e) {
-        logger.error("could not run a DNS query on " + ipAddress);
+        logger.error("could not run a DNS query on {}", ipAddress);
+        logger.trace("", e);
       }
     }
     return new ModelAndView(getViewName(), "result", lines)

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -38,10 +38,10 @@ public class AjaxReloadContextController extends ContextHandlerController {
 
     if (!request.getContextPath().equals(contextName) && context != null) {
       try {
-        logger.info(request.getRemoteAddr() + " requested RELOAD of " + contextName);
+        logger.info("{} requested RELOAD of {}", request.getRemoteAddr(), contextName);
         context.reload();
       } catch (Exception e) {
-        logger.error("Error during ajax request to RELOAD of " + contextName, e);
+        logger.error("Error during ajax request to RELOAD of '{}'", contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -39,14 +39,14 @@ public class AjaxToggleContextController extends ContextHandlerController {
     if (!request.getContextPath().equals(contextName) && context != null) {
       try {
         if (context.getState().isAvailable()) {
-          logger.info(request.getRemoteAddr() + " requested STOP of " + contextName);
+          logger.info("{} requested STOP of {}", request.getRemoteAddr(), contextName);
           getContainerWrapper().getTomcatContainer().stop(contextName);
         } else {
-          logger.info(request.getRemoteAddr() + " requested START of " + contextName);
+          logger.info("{} requested START of {}", request.getRemoteAddr(), contextName);
           getContainerWrapper().getTomcatContainer().start(contextName);
         }
       } catch (Exception e) {
-        logger.error("Error during ajax request to START/STOP of " + contextName, e);
+        logger.error("Error during ajax request to START/STOP of '{}'", contextName, e);
       }
     }
     return new ModelAndView(getViewName(), "available", context != null

--- a/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
@@ -87,11 +87,10 @@ public class DownloadXmlConfController extends ContextHandlerController {
       if (xmlFile.exists()) {
         Utils.sendFile(request, response, xmlFile);
       } else {
-        logger.debug("File " + xmlPath + " of " + contextName + " application does not exists.");
+        logger.debug("File {} of {} application does not exists.", xmlPath, contextName);
       }
     } else {
-      logger.debug("Cannot determine path to " + getDownloadTarget() + " file of " + contextName
-          + " application.");
+      logger.debug("Cannot determine path to {} file of {} application.", getDownloadTarget(), contextName);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
@@ -132,11 +132,10 @@ public class ViewXmlConfController extends ContextHandlerController {
           fis.close();
         }
       } else {
-        logger.debug("File " + xmlPath + " of " + contextName + " application does not exists.");
+        logger.debug("File {} of {} application does not exists.", xmlPath, contextName);
       }
     } else {
-      logger.debug("Cannot determine path to " + getDisplayTarget() + " file of " + contextName
-          + " application.");
+      logger.debug("Cannot determine path to {} file of {} application.", getDisplayTarget(), contextName);
     }
 
     return mv;

--- a/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
@@ -80,6 +80,7 @@ public class ResetDataSourceController extends ContextHandlerController {
             "errorMessage",
             getMessageSourceAccessor().getMessage("probe.src.reset.datasource.notfound",
                 new Object[] {resourceName}));
+        logger.trace("", e);
       }
       if (!reset) {
         request.setAttribute("errorMessage",
@@ -87,7 +88,7 @@ public class ResetDataSourceController extends ContextHandlerController {
       }
 
     }
-    logger.debug("Redirected to " + redirectUrl);
+    logger.debug("Redirected to {}", redirectUrl);
     return new ModelAndView(new RedirectView(redirectUrl));
   }
 

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
@@ -48,6 +48,7 @@ public class DeployContextController extends TomcatContainerController {
         }
       } catch (Exception e) {
         request.setAttribute("errorMessage", e.getMessage());
+        logger.trace("", e);
       }
     }
 

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -68,7 +68,7 @@ public class UndeployContextController extends ContextHandlerController {
 
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());
-      logger.error("Error during undeploy of " + contextName, e);
+      logger.error("Error during undeploy of '{}'", contextName, e);
       return new ModelAndView(new InternalResourceView(getFailureViewName() == null ? getViewName()
           : getFailureViewName()));
     }

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -120,7 +120,7 @@ public class UploadWarController extends TomcatContainerController {
             if (update
                 && getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
 
-              logger.debug("updating " + contextName + ": removing the old copy");
+              logger.debug("updating {}: removing the old copy", contextName);
               getContainerWrapper().getTomcatContainer().remove(contextName);
             }
 

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
@@ -93,7 +93,7 @@ public class ViewSourceController extends ContextHandlerController {
           }
 
         } else {
-          logger.error(jspName + " does not exist");
+          logger.error("{} does not exist", jspName);
         }
 
         request.setAttribute("item", item);
@@ -103,7 +103,7 @@ public class ViewSourceController extends ContextHandlerController {
       }
     } else {
       if (jspName == null) {
-        logger.error("Passed empty \"source\" parameter");
+        logger.error("Passed empty 'source' parameter");
       }
       if (summary == null) {
         logger.error("Session has expired or there is no summary");

--- a/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
@@ -42,8 +42,8 @@ public class DownloadLogController extends LogHandlerController {
     boolean compressed = "true".equals(ServletRequestUtils.getStringParameter(request, "compressed"));
     
     File file = logDest.getFile();
-    logger.info("Sending " + file + (compressed ? " compressed" : "") + " to " + request.getRemoteAddr() + "("
-        + request.getRemoteUser() + ")");
+    logger.info("Sending {}{} to {} ({})", file, (compressed ? " compressed" : ""), request.getRemoteAddr(),
+        request.getRemoteUser());
     if (compressed) {
       Utils.sendCompressedFile(request, response, file);
     } else {

--- a/core/src/main/java/psiprobe/controllers/logs/LogHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/LogHandlerController.java
@@ -78,11 +78,10 @@ public class LogHandlerController extends ParameterizableViewController {
         modelAndView = handleLogFile(request, response, dest);
         logFound = true;
       } else {
-        logger.error(dest.getFile() + ": file not found");
+        logger.error("{}: file not found", dest.getFile());
       }
     } else {
-      logger.error(logType + (root ? " root" : "") + " log" + (root ? "" : " \"" + logName + "\"")
-          + " not found");
+      logger.error("{}{} log{} not found", logType, (root ? " root" : ""), (root ? "" : " '" + logName + "'"));
     }
     if (!logFound) {
       response.sendError(404);

--- a/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
@@ -62,8 +62,8 @@ public class CachedRecordSetController extends ParameterizableViewController {
             "errorMessage",
             getMessageSourceAccessor().getMessage(
                 "probe.src.dataSourceTest.cachedResultSet.failure"));
-        logger.error("Cannot retrieve a cached result set. " + DataSourceTestInfo.DS_TEST_SESS_ATTR
-            + " session attribute is NULL.");
+        logger.error("Cannot retrieve a cached result set. {} session attribute is NULL.",
+                DataSourceTestInfo.DS_TEST_SESS_ATTR);
       } else {
         synchronized (sess) {
           sessData.setRowsPerPage(rowsPerPage);

--- a/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
@@ -61,6 +61,7 @@ public class ConnectionTestController extends ContextHandlerController {
           "errorMessage",
           getMessageSourceAccessor().getMessage("probe.src.dataSourceTest.resource.lookup.failure",
               new Object[] {resourceName}));
+      logger.trace("", e);
     }
 
     if (dataSource == null) {

--- a/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
@@ -97,6 +97,7 @@ public class ExecuteSqlController extends ContextHandlerController {
           "errorMessage",
           getMessageSourceAccessor().getMessage("probe.src.dataSourceTest.resource.lookup.failure",
               new Object[] {resourceName}));
+      logger.trace("", e);
     }
 
     if (dataSource == null) {

--- a/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
@@ -56,7 +56,8 @@ public class QueryHistoryItemController extends AbstractController {
             response.setCharacterEncoding("UTF-8");
             response.getWriter().print(sql);
           } catch (IndexOutOfBoundsException e) {
-            logger.error("Cannot find a query history entry for history item id = " + sqlId);
+            logger.error("Cannot find a query history entry for history item id = {}", sqlId);
+            logger.trace("", e);
           }
         }
       }

--- a/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
+++ b/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
@@ -72,7 +72,7 @@ public class AdviseGarbageCollectionController extends ParameterizableViewContro
       Runtime.getRuntime().gc();
       logger.debug("Advised Garbage Collection");
     }
-    logger.debug("Redirected to " + redirectUrl);
+    logger.debug("Redirected to {}", redirectUrl);
     return new ModelAndView(new RedirectView(redirectUrl));
   }
 

--- a/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
@@ -49,8 +49,7 @@ public class GetClassLoaderUrlsController extends ParameterizableViewController 
         try {
           request.setAttribute("urls", Arrays.asList(((URLClassLoader) cl).getURLs()));
         } catch (Exception e) {
-          logger.error("There was an exception querying classloader for thread \"" + threadName
-              + "\"", e);
+          logger.error("There was an exception querying classloader for thread '{}'", threadName, e);
         }
       }
     }

--- a/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
@@ -37,11 +37,12 @@ public class RestartJvmController extends ParameterizableViewController {
     boolean done = false;
     try {
       Class.forName("org.tanukisoftware.wrapper.WrapperManager");
-      logger.info("JVM is RESTARTED by " + request.getRemoteAddr());
+      logger.info("JVM is RESTARTED by {}", request.getRemoteAddr());
       WrapperManager.restartAndReturn();
       done = true;
     } catch (ClassNotFoundException e) {
       logger.info("WrapperManager not found. Do you have wrapper.jar in the classpath?");
+      logger.trace("", e);
     }
     return new ModelAndView(getViewName(), "done", done);
   }

--- a/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
@@ -58,11 +58,12 @@ public class StopJvmController extends ParameterizableViewController {
     boolean done = false;
     try {
       Class.forName("org.tanukisoftware.wrapper.WrapperManager");
-      logger.info("JVM is STOPPED by " + request.getRemoteAddr());
+      logger.info("JVM is STOPPED by {}", request.getRemoteAddr());
       WrapperManager.stop(stopExitCode);
       done = true;
     } catch (ClassNotFoundException e) {
       logger.info("WrapperManager not found. Do you have wrapper.jar in the classpath?");
+      logger.trace("", e);
     }
     return new ModelAndView(getViewName(), "done", done);
   }

--- a/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
@@ -37,11 +37,12 @@ public class ThreadDumpController extends ParameterizableViewController {
     boolean done = false;
     try {
       Class.forName("org.tanukisoftware.wrapper.WrapperManager");
-      logger.info("ThreadDump requested by " + request.getRemoteAddr());
+      logger.info("ThreadDump requested by {}", request.getRemoteAddr());
       WrapperManager.requestThreadDump();
       done = true;
     } catch (ClassNotFoundException e) {
       logger.info("WrapperManager not found. Do you have wrapper.jar in the classpath?");
+      logger.trace("", e);
     }
     return new ModelAndView(getViewName(), "done", done);
   }

--- a/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
@@ -54,6 +54,7 @@ public class WrapperInfoController extends ParameterizableViewController {
       wi.setLaunchedAsService(WrapperManager.isLaunchedAsService());
     } catch (ClassNotFoundException e) {
       logger.info("Could not find WrapperManager class. Is wrapper.jar in the classpath?");
+      logger.trace("", e);
       wi.setControlledByWrapper(false);
     }
     return new ModelAndView(getViewName(), "wrapperInfo", wi);

--- a/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
+++ b/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
@@ -19,6 +19,9 @@ import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.BodyContent;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class VisualScoreTag.
  *
@@ -29,6 +32,9 @@ public class VisualScoreTag extends BodyTagSupport {
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = -5653846466205838602L;
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(VisualScoreTag.class);
 
   /** The Constant WHITE_LEFT_BORDER. */
   private static final String WHITE_LEFT_BORDER = "a0";
@@ -97,8 +103,9 @@ public class VisualScoreTag extends BodyTagSupport {
     try {
       JspWriter out = bc.getEnclosingWriter();
       out.print(buf);
-    } catch (IOException ioe) {
-      throw new JspException("Error:IOException while writing to client" + ioe.getMessage());
+    } catch (IOException e) {
+      logger.trace("", e);
+      throw new JspException("Error:IOException while writing to client" + e.getMessage());
     }
 
     return SKIP_BODY;

--- a/core/src/main/java/psiprobe/model/SessionSearchInfo.java
+++ b/core/src/main/java/psiprobe/model/SessionSearchInfo.java
@@ -17,6 +17,9 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Data model class used by session search feature of application session screen.
  * 
@@ -27,6 +30,9 @@ public class SessionSearchInfo implements Serializable {
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = 1L;
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(SessionSearchInfo.class);
 
   /** The Constant SESS_ATTR_NAME. */
   public static final String SESS_ATTR_NAME = "sessionSearchInfo";
@@ -321,6 +327,7 @@ public class SessionSearchInfo implements Serializable {
       try {
         sessionIdPattern = Pattern.compile(sessionId);
       } catch (PatternSyntaxException e) {
+        logger.trace("", e);
         sessionIdMsg = e.getDescription();
       }
     }
@@ -372,6 +379,7 @@ public class SessionSearchInfo implements Serializable {
           try {
             attrNamePatterns.add(Pattern.compile(regex));
           } catch (PatternSyntaxException e) {
+            logger.trace("", e);
             attrNameMsgs.add(e.getDescription());
           }
         }
@@ -419,7 +427,7 @@ public class SessionSearchInfo implements Serializable {
       try {
         ageFromSec = Integer.valueOf(ageFrom);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
   }
@@ -455,7 +463,7 @@ public class SessionSearchInfo implements Serializable {
       try {
         ageToSec = Integer.valueOf(ageTo);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
   }
@@ -491,7 +499,7 @@ public class SessionSearchInfo implements Serializable {
       try {
         idleTimeFromSec = Integer.valueOf(idleTimeFrom);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
   }
@@ -527,7 +535,7 @@ public class SessionSearchInfo implements Serializable {
       try {
         idleTimeToSec = Integer.valueOf(idleTimeTo);
       } catch (NumberFormatException e) {
-        // ignore
+        logger.trace("", e);
       }
     }
   }

--- a/core/src/main/java/psiprobe/model/stats/StatsCollection.java
+++ b/core/src/main/java/psiprobe/model/stats/StatsCollection.java
@@ -245,10 +245,10 @@ public class StatsCollection implements InitializingBean, DisposableBean, Applic
         os.close();
       }
     } catch (Exception e) {
-      logger.error("Could not write stats data to " + makeFile().getAbsolutePath(), e);
+      logger.error("Could not write stats data to '{}'", makeFile().getAbsolutePath(), e);
     } finally {
       lock.releaseCommitLock();
-      logger.debug("stats serialized in " + (System.currentTimeMillis() - start) + "ms.");
+      logger.debug("stats serialized in {}ms", (System.currentTimeMillis() - start));
     }
   }
 
@@ -288,9 +288,9 @@ public class StatsCollection implements InitializingBean, DisposableBean, Applic
         } finally {
           fis.close();
         }
-        logger.debug("stats data read in " + (System.currentTimeMillis() - start) + "ms.");
+        logger.debug("stats data read in {}ms", (System.currentTimeMillis() - start));
       } catch (Exception e) {
-        logger.error("Could not read stats data from " + file.getAbsolutePath(), e);
+        logger.error("Could not read stats data from '{}'", file.getAbsolutePath(), e);
       }
     }
 

--- a/core/src/main/java/psiprobe/tokenizer/StringTokenizer.java
+++ b/core/src/main/java/psiprobe/tokenizer/StringTokenizer.java
@@ -14,12 +14,18 @@ package psiprobe.tokenizer;
 import java.io.IOException;
 import java.io.StringReader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class StringTokenizer.
  *
  * @author Vlad Ilyushchenko
  */
 public class StringTokenizer extends Tokenizer {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(StringTokenizer.class);
 
   /**
    * Instantiates a new string tokenizer.
@@ -51,6 +57,7 @@ public class StringTokenizer extends Tokenizer {
     try {
       return super.hasMore();
     } catch (IOException e) {
+      logger.trace("", e);
       return false;
     }
   }
@@ -60,6 +67,7 @@ public class StringTokenizer extends Tokenizer {
     try {
       return super.getToken();
     } catch (IOException e) {
+      logger.trace("", e);
       return null;
     }
   }
@@ -69,6 +77,7 @@ public class StringTokenizer extends Tokenizer {
     try {
       return super.nextToken();
     } catch (IOException e) {
+      logger.trace("", e);
       return null;
     }
   }

--- a/core/src/main/java/psiprobe/tokenizer/Tokenizer.java
+++ b/core/src/main/java/psiprobe/tokenizer/Tokenizer.java
@@ -16,12 +16,18 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class Tokenizer.
  *
  * @author Vlad Ilyushchenko
  */
 public class Tokenizer {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(Tokenizer.class);
 
   /** The Constant TT_TOKEN. */
   public static final int TT_TOKEN = 0;
@@ -392,6 +398,7 @@ public class Tokenizer {
     try {
       return Long.parseLong(stval);
     } catch (NumberFormatException e) {
+      logger.trace("", e);
       return defaultValue;
     }
   }

--- a/core/src/main/java/psiprobe/tools/AccessorFactory.java
+++ b/core/src/main/java/psiprobe/tools/AccessorFactory.java
@@ -11,12 +11,18 @@
 
 package psiprobe.tools;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A factory for creating Accessor objects.
  *
  * @author Mark Lewis
  */
 public class AccessorFactory {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(AccessorFactory.class);
 
   /**
    * Prevent Instantiation of accessor factory.
@@ -44,12 +50,16 @@ public class AccessorFactory {
     try {
       return new ReflectiveAccessor();
     } catch (ClassNotFoundException e) {
+      logger.trace("", e);
       return null;
     } catch (InstantiationException e) {
+      logger.trace("", e);
       return null;
     } catch (IllegalAccessException e) {
+      logger.trace("", e);
       return null;
     } catch (NoSuchMethodException e) {
+      logger.trace("", e);
       return null;
     }
   }

--- a/core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -89,7 +89,7 @@ public class ApplicationUtils {
       boolean calcSize, ContainerWrapperBean containerWrapper) {
 
     // ContainerWrapperBean containerWrapper
-    logger.debug("Querying webapp: " + context.getName());
+    logger.debug("Querying webapp: {}", context.getName());
 
     Application app = new Application();
     app.setName(context.getName().length() > 0 ? context.getName() : "/");
@@ -259,7 +259,7 @@ public class ApplicationUtils {
               objSize += Instruments.sizeOf(name, processedObjects);
               objSize += Instruments.sizeOf(obj, processedObjects);
             } catch (Exception ex) {
-              logger.error("Cannot estimate size of attribute '{}' {}", name, ex);
+              logger.error("Cannot estimate size of attribute '{}'", name, ex);
             }
           }
 
@@ -284,12 +284,14 @@ public class ApplicationUtils {
           sbean.setLastAccessedIpLocale(InetAddressLocator.getLocale(InetAddress.getByName(
               lastAccessedIp).getAddress()));
         } catch (Exception e) {
-          logger.error("Cannot determine Locale of " + lastAccessedIp);
+          logger.error("Cannot determine Locale of {}", lastAccessedIp);
+          logger.trace("", e);
         }
 
 
       } catch (IllegalStateException e) {
         logger.info("Session appears to be invalidated, ignore");
+        logger.trace("", e);
       }
 
       sbean.setObjectCount(attributeCount);

--- a/core/src/main/java/psiprobe/tools/AsyncSocketFactory.java
+++ b/core/src/main/java/psiprobe/tools/AsyncSocketFactory.java
@@ -14,12 +14,18 @@ package psiprobe.tools;
 import java.io.IOException;
 import java.net.Socket;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A factory for creating AsyncSocket objects.
  *
  * @author Vlad Ilyushchenko
  */
 public class AsyncSocketFactory {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(AsyncSocketFactory.class);
 
   /**
    * Creates a new AsyncSocket object.
@@ -49,7 +55,7 @@ public class AsyncSocketFactory {
         try {
           sync.wait(timeout * 1000);
         } catch (InterruptedException e) {
-          //
+          logger.trace("", e);
         }
       }
     }
@@ -175,6 +181,7 @@ public class AsyncSocketFactory {
           socketWrapper.setSocket(null);
         }
       } catch (IOException e) {
+        logger.trace("", e);
         socketWrapper.setException(e);
       }
       synchronized (sync) {
@@ -214,7 +221,7 @@ public class AsyncSocketFactory {
           sync.notify();
         }
       } catch (InterruptedException e) {
-        //
+        logger.trace("", e);
       }
     }
 

--- a/core/src/main/java/psiprobe/tools/JmxTools.java
+++ b/core/src/main/java/psiprobe/tools/JmxTools.java
@@ -46,7 +46,8 @@ public class JmxTools {
     try {
       return mbeanServer.getAttribute(objName, attrName);
     } catch (AttributeNotFoundException e) {
-      logger.error(objName + " does not have \"" + attrName + "\" attribute");
+      logger.error("{} does not have '{}' attribute", objName, attrName);
+      logger.trace("", e);
       return null;
     }
   }
@@ -67,6 +68,7 @@ public class JmxTools {
       Object obj = mbeanServer.getAttribute(objName, attrName);
       return obj == null ? defaultValue : ((Long) obj);
     } catch (Exception e) {
+      logger.trace("", e);
       return defaultValue;
     }
   }

--- a/core/src/main/java/psiprobe/tools/ReflectiveAccessor.java
+++ b/core/src/main/java/psiprobe/tools/ReflectiveAccessor.java
@@ -17,12 +17,18 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class ReflectiveAccessor.
  *
  * @author Mark Lewis
  */
 public class ReflectiveAccessor implements Accessor {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(ReflectiveAccessor.class);
 
   /** The reflection factory. */
   private static Object reflectionFactory;
@@ -55,11 +61,11 @@ public class ReflectiveAccessor implements Accessor {
         return get.invoke(fieldAccessor, new Object[] {obj});
       }
     } catch (IllegalArgumentException e) {
-      // ignore
+      logger.trace("", e);
     } catch (IllegalAccessException e) {
-      // ignore
+      logger.trace("", e);
     } catch (InvocationTargetException e) {
-      // ignore
+      logger.trace("", e);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/tools/SimpleAccessor.java
+++ b/core/src/main/java/psiprobe/tools/SimpleAccessor.java
@@ -13,6 +13,9 @@ package psiprobe.tools;
 
 import java.lang.reflect.Field;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class SimpleAccessor.
  *
@@ -20,14 +23,19 @@ import java.lang.reflect.Field;
  */
 public class SimpleAccessor implements Accessor {
 
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(SimpleAccessor.class);
+
   @Override
   public Object get(Object obj, Field field) {
     boolean accessible = pre(field);
     try {
       return get0(obj, field);
     } catch (IllegalArgumentException e) {
+      logger.trace("", e);
       return null;
     } catch (IllegalAccessException e) {
+      logger.trace("", e);
       return null;
     } finally {
       post(field, accessible);
@@ -64,7 +72,7 @@ public class SimpleAccessor implements Accessor {
       try {
         field.setAccessible(true);
       } catch (SecurityException ex) {
-        // ignore
+        logger.trace("", ex);
       }
     }
     return accessible;
@@ -81,7 +89,7 @@ public class SimpleAccessor implements Accessor {
       try {
         field.setAccessible(false);
       } catch (SecurityException ex) {
-        // ignore
+        logger.trace("", ex);
       }
     }
   }

--- a/core/src/main/java/psiprobe/tools/Whois.java
+++ b/core/src/main/java/psiprobe/tools/Whois.java
@@ -19,6 +19,9 @@ import java.net.Socket;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import psiprobe.tools.url.UrlParser;
 
 /**
@@ -27,6 +30,9 @@ import psiprobe.tools.url.UrlParser;
  * @author Vlad Ilyushchenko
  */
 public class Whois {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(Whois.class);
 
   /**
    * Lookup.
@@ -116,8 +122,7 @@ public class Whois {
                         lineSeparator);
               }
             } catch (IOException e) {
-              // System.out.println("Could not contact " + referral);
-
+              logger.trace("Could not contact '{}'", referral, e);
             }
           }
           if (newResponse != null) {

--- a/core/src/main/java/psiprobe/tools/logging/DefaultAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/DefaultAccessor.java
@@ -96,13 +96,13 @@ public class DefaultAccessor {
           ? PropertyUtils.getProperty(obj, name)
           : defaultValue;
     } catch (IllegalArgumentException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     } catch (IllegalAccessException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     } catch (InvocationTargetException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     } catch (NoSuchMethodException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     }
     logger.debug("Could not access property '{}' of object '{}'", name, obj);
     return defaultValue;
@@ -124,11 +124,11 @@ public class DefaultAccessor {
       }
       return MethodUtils.invokeMethod(object, name, param);
     } catch (NoSuchMethodException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     } catch (IllegalAccessException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     } catch (InvocationTargetException e) {
-      logger.error("{}", e);
+      logger.error("", e);
     }
     return defaultValue;
   }

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14HandlerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14HandlerAccessor.java
@@ -97,7 +97,7 @@ public class Jdk14HandlerAccessor extends AbstractLogDestination {
       Object newLevel = MethodUtils.invokeMethod(level, "parse", newLevelStr);
       MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+      logger.error("{}#setLevel('{}') failed", getTarget().getClass().getName(), newLevelStr, e);
     }
   }
 

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
@@ -48,7 +48,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
         }
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#handlers inaccessible", e);
+      logger.error("{}#handlers inaccessible", getTarget().getClass().getName(), e);
     }
     return handlerAccessors;
   }
@@ -109,7 +109,8 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
     try {
       index = Integer.parseInt(logIndex);
     } catch (Exception e) {
-      logger.info("Could not parse integer from: " + logIndex + ".  Assuming 0.");
+      logger.info("Could not parse integer from: {}.  Assuming 0.", logIndex);
+      logger.trace("", e);
     }
     return getHandler(index);
   }
@@ -125,7 +126,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
       Object[] handlers = (Object[]) MethodUtils.invokeMethod(getTarget(), "getHandlers", null);
       return wrapHandler(handlers[index], index);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#handlers inaccessible", e);
+      logger.error("{}#handlers inaccessible", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -148,7 +149,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
       }
       return (String) MethodUtils.invokeMethod(level, "getName", null);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLevel() failed", e);
+      logger.error("{}#getLevel() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -166,7 +167,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
       Object newLevel = parse.invoke(null, new Object[] {newLevelStr});
       MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+      logger.error("{}#setLevel('{}') failed", getTarget().getClass().getName(), newLevelStr, e);
     }
   }
 
@@ -208,7 +209,7 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
       }
       return handlerAccessor;
     } catch (Exception e) {
-      logger.error("Could not wrap handler: " + handler, e);
+      logger.error("Could not wrap handler: '{}'", handler, e);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
@@ -78,7 +78,7 @@ public class Jdk14ManagerAccessor extends DefaultAccessor {
       accessor.setApplication(getApplication());
       return accessor;
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLogger(\"" + name + "\") failed", e);
+      logger.error("{}#getLogger('{}') failed", getTarget().getClass().getName(), name, e);
     }
     return null;
   }
@@ -102,7 +102,7 @@ public class Jdk14ManagerAccessor extends DefaultAccessor {
         }
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLoggerNames() failed", e);
+      logger.error("{}#getLoggerNames() failed", getTarget().getClass().getName(), e);
     }
     return allHandlers;
   }

--- a/core/src/main/java/psiprobe/tools/logging/log4j/Log4JLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j/Log4JLoggerAccessor.java
@@ -48,7 +48,7 @@ public class Log4JLoggerAccessor extends DefaultAccessor {
         }
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAllAppenders() failed", e);
+      logger.error("{}#getAllAppenders() failed", getTarget().getClass().getName(), e);
     }
     return appenders;
   }
@@ -64,7 +64,7 @@ public class Log4JLoggerAccessor extends DefaultAccessor {
       Object appender = MethodUtils.invokeMethod(getTarget(), "getAppender", name);
       return wrapAppender(appender);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAppender() failed", e);
+      logger.error("{}#getAppender() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -115,7 +115,7 @@ public class Log4JLoggerAccessor extends DefaultAccessor {
       Object level = MethodUtils.invokeMethod(getTarget(), "getLevel", null);
       return (String) MethodUtils.invokeMethod(level, "toString", null);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLevel() failed", e);
+      logger.error("{}#getLevel() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -131,7 +131,7 @@ public class Log4JLoggerAccessor extends DefaultAccessor {
       Object newLevel = MethodUtils.invokeMethod(level, "toLevel", newLevelStr);
       MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+      logger.error("{}#setLevel('{}') failed",getTarget().getClass().getName(), newLevelStr, e);
     }
   }
 
@@ -152,7 +152,7 @@ public class Log4JLoggerAccessor extends DefaultAccessor {
       appenderAccessor.setApplication(getApplication());
       return appenderAccessor;
     } catch (Exception e) {
-      logger.error("Could not wrap appender: " + appender, e);
+      logger.error("Could not wrap appender: {}", appender, e);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
@@ -64,7 +64,7 @@ public class Log4JManagerAccessor extends DefaultAccessor {
       accessor.setApplication(getApplication());
       return accessor;
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getRootLogger() failed", e);
+      logger.error("{}#getRootLogger() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -91,7 +91,7 @@ public class Log4JManagerAccessor extends DefaultAccessor {
       accessor.setApplication(getApplication());
       return accessor;
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLogger(\"" + name + "\") failed", e);
+      logger.error("{}#getLogger('{}') failed", getTarget().getClass().getName(), name, e);
     }
     return null;
   }
@@ -119,7 +119,7 @@ public class Log4JManagerAccessor extends DefaultAccessor {
         appenders.addAll(accessor.getAppenders());
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getCurrentLoggers() failed", e);
+      logger.error("{}#getCurrentLoggers() failed", getTarget().getClass().getName(), e);
     }
     return appenders;
   }

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
@@ -98,7 +98,7 @@ public class LogbackFactoryAccessor extends DefaultAccessor {
       return accessor;
 
     } catch (Exception e) {
-      logger.error(getTarget() + ".getLogger(\"" + name + "\") failed", e);
+      logger.error("{}.getLogger('{}') failed", getTarget(), name, e);
     }
     return null;
   }
@@ -125,7 +125,7 @@ public class LogbackFactoryAccessor extends DefaultAccessor {
         appenders.addAll(accessor.getAppenders());
       }
     } catch (Exception e) {
-      logger.error(getTarget() + ".getLoggerList() failed", e);
+      logger.error("{}.getLoggerList() failed", getTarget(), e);
     }
     return appenders;
   }

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
@@ -49,7 +49,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
         }
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAppenders() failed", e);
+      logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
     }
     return appenders;
   }
@@ -73,7 +73,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
       }
       return wrapAppender(appender);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAppender() failed", e);
+      logger.error("{}#getAppender() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -115,7 +115,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
       Object level = MethodUtils.invokeMethod(getTarget(), "getLevel", null);
       return (String) MethodUtils.invokeMethod(level, "toString", null);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLevel() failed", e);
+      logger.error("{}#getLevel() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -131,7 +131,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
       Object newLevel = MethodUtils.invokeMethod(level, "toLevel", newLevelStr);
       MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+      logger.error("{}#setLevel('{}') failed", getTarget().getClass().getName(), newLevelStr, e);
     }
   }
 
@@ -150,6 +150,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
           return (List<Object>) MethodUtils.invokeMethod(tracker, "allComponents", null);
         } catch (final NoSuchMethodException e) {
             // XXX Legacy 1.0.x and lower support for logback
+            logger.trace("", e);
             return (List<Object>) MethodUtils.invokeMethod(tracker, "valueList", null);
         }
       }
@@ -188,7 +189,7 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
       appenderAccessor.setApplication(getApplication());
       return appenderAccessor;
     } catch (Exception e) {
-      logger.error("Could not wrap appender: " + appender, e);
+      logger.error("Could not wrap appender: '{}'", appender, e);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
@@ -102,7 +102,7 @@ public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
       return accessor;
 
     } catch (Exception e) {
-      logger.error(getTarget() + ".getLogger(\"" + name + "\") failed", e);
+      logger.error("{}.getLogger('{}') failed", getTarget(), name, e);
     }
     return null;
   }
@@ -131,7 +131,7 @@ public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
         appenders.addAll(accessor.getAppenders());
       }
     } catch (Exception e) {
-      logger.error(getTarget() + ".getLoggerList() failed", e);
+      logger.error("{}.getLoggerList() failed", getTarget(), e);
     }
     return appenders;
   }

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
@@ -50,7 +50,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
         }
       }
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAppenders() failed", e);
+      logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
     }
     return appenders;
   }
@@ -75,7 +75,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
       }
       return wrapAppender(appender);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getAppender() failed", e);
+      logger.error("{}#getAppender() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -117,7 +117,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
       Object level = MethodUtils.invokeMethod(getTarget(), "getLevel", null);
       return (String) MethodUtils.invokeMethod(level, "toString", null);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#getLevel() failed", e);
+      logger.error("{}#getLevel() failed", getTarget().getClass().getName(), e);
     }
     return null;
   }
@@ -133,7 +133,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
       Object newLevel = MethodUtils.invokeMethod(level, "toLevel", newLevelStr);
       MethodUtils.invokeMethod(getTarget(), "setLevel", newLevel);
     } catch (Exception e) {
-      logger.error(getTarget().getClass().getName() + "#setLevel(\"" + newLevelStr + "\") failed", e);
+      logger.error("{}#setLevel('{}') failed", getTarget().getClass().getName(), newLevelStr, e);
     }
   }
 
@@ -191,7 +191,7 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
       appenderAccessor.setApplication(getApplication());
       return appenderAccessor;
     } catch (IllegalArgumentException e) {
-      logger.error("Could not wrap appender: " + appender, e);
+      logger.error("Could not wrap appender: '{}'", appender, e);
     }
     return null;
   }

--- a/core/src/main/java/psiprobe/tools/url/UrlParser.java
+++ b/core/src/main/java/psiprobe/tools/url/UrlParser.java
@@ -13,12 +13,18 @@ package psiprobe.tools.url;
 
 import java.net.MalformedURLException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The Class UrlParser.
  *
  * @author Vlad Ilyushchenko
  */
 public class UrlParser {
+
+  /** The Constant Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(UrlParser.class);
 
   /** The protocol. */
   private String protocol;
@@ -65,6 +71,7 @@ public class UrlParser {
         try {
           this.port = Integer.parseInt(portString);
         } catch (NumberFormatException e) {
+          logger.trace("", e);
           throw new MalformedURLException("Invalid port " + portString);
         }
       } else {

--- a/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
+++ b/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
@@ -120,7 +120,7 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
     NamingResources namingResources = context.getNamingResources();
     for (ContextResourceLink link : namingResources.findResourceLinks()) {
       ApplicationResource resource = new ApplicationResource();
-      logger.debug("reading resourceLink: " + link.getName());
+      logger.debug("reading resourceLink: {}", link.getName());
       resource.setApplicationName(context.getName());
       resource.setName(link.getName());
       resource.setType(link.getType());
@@ -136,7 +136,7 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
     NamingResources namingResources = context.getNamingResources();
     for (ContextResource contextResource : namingResources.findResources()) {
       ApplicationResource resource = new ApplicationResource();
-      logger.info("reading resource: " + contextResource.getName());
+      logger.info("reading resource: {}", contextResource.getName());
       resource.setApplicationName(context.getName());
       resource.setName(contextResource.getName());
       resource.setType(contextResource.getType());
@@ -274,6 +274,7 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
     try {
       return context.getResources().lookup(name) != null;
     } catch (NamingException ex) {
+      logger.trace("", ex);
       throw new RuntimeException(ex);
     }
   }
@@ -283,6 +284,7 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
     try {
       return ((Resource) context.getResources().lookup(name)).streamContent();
     } catch (NamingException ex) {
+      logger.trace("", ex);
       throw new RuntimeException(ex);
     }
   }
@@ -295,7 +297,7 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
       result[0] = resource.getContentLength();
       result[1] = resource.getLastModified();
     } catch (NamingException ex) {
-      // Don't care
+      logger.trace("", ex);
     }
     return result;
   }

--- a/tomcat80adapter/src/main/java/psiprobe/Tomcat80ContainerAdapter.java
+++ b/tomcat80adapter/src/main/java/psiprobe/Tomcat80ContainerAdapter.java
@@ -114,7 +114,7 @@ public class Tomcat80ContainerAdapter extends AbstractTomcatContainer {
     NamingResourcesImpl namingResources = context.getNamingResources();
     for (ContextResourceLink link : namingResources.findResourceLinks()) {
       ApplicationResource resource = new ApplicationResource();
-      logger.debug("reading resourceLink: " + link.getName());
+      logger.debug("reading resourceLink: {}", link.getName());
       resource.setApplicationName(context.getName());
       resource.setName(link.getName());
       resource.setType(link.getType());
@@ -132,7 +132,7 @@ public class Tomcat80ContainerAdapter extends AbstractTomcatContainer {
     for (ContextResource contextResource : namingResources.findResources()) {
       ApplicationResource resource = new ApplicationResource();
 
-      logger.info("reading resource: " + contextResource.getName());
+      logger.info("reading resource: {}", contextResource.getName());
       resource.setApplicationName(context.getName());
       resource.setName(contextResource.getName());
       resource.setType(contextResource.getType());

--- a/tomcat90adapter/src/main/java/psiprobe/Tomcat90ContainerAdapter.java
+++ b/tomcat90adapter/src/main/java/psiprobe/Tomcat90ContainerAdapter.java
@@ -115,7 +115,7 @@ public class Tomcat90ContainerAdapter extends AbstractTomcatContainer {
     NamingResourcesImpl namingResources = context.getNamingResources();
     for (ContextResourceLink link : namingResources.findResourceLinks()) {
       ApplicationResource resource = new ApplicationResource();
-      logger.debug("reading resourceLink: " + link.getName());
+      logger.debug("reading resourceLink: {}", link.getName());
       resource.setApplicationName(context.getName());
       resource.setName(link.getName());
       resource.setType(link.getType());
@@ -133,7 +133,7 @@ public class Tomcat90ContainerAdapter extends AbstractTomcatContainer {
     for (ContextResource contextResource : namingResources.findResources()) {
       ApplicationResource resource = new ApplicationResource();
 
-      logger.info("reading resource: " + contextResource.getName());
+      logger.info("reading resource: {}", contextResource.getName());
       resource.setApplicationName(context.getName());
       resource.setName(contextResource.getName());
       resource.setType(contextResource.getType());


### PR DESCRIPTION
This is pretty large given it attempts to address all logging instances.  There is a chance I missed a few.  Overall, the point here is that not using string concationation allows us to delegate to the logging facet and only if it determines we are logging as specified level will it perform any work on values passed in.  This essentially ensures we get better speed on logging.