### PR TITLE
Correct SCM Urls

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,8 +15,8 @@
 		PSI Probe Core - Core logic, data models, and controllers
 	</description>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 		</mailingList>
 	</mailingLists>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<modules>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -15,8 +15,8 @@
         PSI Probe Rest - RESTful service endpoints.
     </description>
     <scm>
-        <connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+        <connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
     <properties>

--- a/tomcat70adapter/pom.xml
+++ b/tomcat70adapter/pom.xml
@@ -15,8 +15,8 @@
 		PSI Probe Tomcat 7.0.x Adapter - Implementation of features specific to Apache Tomcat 7.0.x
 	</description>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<properties>

--- a/tomcat80adapter/pom.xml
+++ b/tomcat80adapter/pom.xml
@@ -15,8 +15,8 @@
 		PSI Probe Tomcat 8.0.x Adapter - Implementation of features specific to Apache Tomcat 8.0.x
 	</description>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<properties>

--- a/tomcat90adapter/pom.xml
+++ b/tomcat90adapter/pom.xml
@@ -15,8 +15,8 @@
 		PSI Probe Tomcat 9.0.x Adapter - Implementation of features specific to Apache Tomcat 9.0.x
 	</description>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,8 +16,8 @@
 		PSI Probe Web Application - Web view, message resources, and configuration
 	</description>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:psi-probe/psi-probe.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</developerConnection>
 		<url>https://github.com/psi-probe/psi-probe/</url>
 	</scm>
 	<properties>


### PR DESCRIPTION
Had a ':' where '/' expected.