### PR TITLE
Update to displaytag 2.0.2 from hazendaz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,23 +246,9 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>displaytag</groupId>
+				<groupId>com.github.hazendaz</groupId>
 				<artifactId>displaytag</artifactId>
-				<version>1.2</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.lowagie</groupId>
-						<artifactId>itext</artifactId>
-					</exclusion>
-					<exclusion>
-						<artifactId>jcl104-over-slf4j</artifactId>
-						<groupId>org.slf4j</groupId>
-					</exclusion>
-					<exclusion>
-						<artifactId>slf4j-log4j12</artifactId>
-						<groupId>org.slf4j</groupId>
-					</exclusion>
-				</exclusions>
+				<version>2.0.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -68,7 +68,7 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>displaytag</groupId>
+			<groupId>com.github.hazendaz</groupId>
 			<artifactId>displaytag</artifactId>
 		</dependency>
 		<dependency>
@@ -82,18 +82,6 @@
 				<groupId>org.jasig.mojo.jspc</groupId>
 				<artifactId>jspc-maven-plugin</artifactId>
 				<dependencies>
-					<dependency>
-						<!-- Required for displaytag -->
-						<groupId>org.slf4j</groupId>
-						<artifactId>jcl104-over-slf4j</artifactId>
-						<version>1.4.2</version>
-					</dependency>
-					<dependency>
-						<!-- Required for displaytag -->
-						<groupId>org.slf4j</groupId>
-						<artifactId>slf4j-nop</artifactId>
-						<version>1.4.2</version>
-					</dependency>
 					<dependency>
 						<groupId>${project.groupId}</groupId>
 						<artifactId>psi-probe-core</artifactId>


### PR DESCRIPTION
In order to get off some legacy slf4j dependencies in our builds, I tracked down displaytag and ported from svn to git and released it to central.  This includes many changes over last 7 years since last release from original authors.  Additionally, it has internally been updated to latest & greatest.  Continued support for displaytag will now reside [here](https://github.com/hazendaz/displaytag).

Enjoy!