### PR TITLE
[tests] Skip Date fields on javabean-tester as it fails under certain…

### DIFF
--- a/core/src/test/java/psiprobe/model/ApplicationSessionTest.java
+++ b/core/src/test/java/psiprobe/model/ApplicationSessionTest.java
@@ -14,9 +14,10 @@ public class ApplicationSessionTest {
   /**
    * Javabean tester.
    */
+  // TODO Until JavabeanTester only uses default no-arg constructor for testing, skip dates.
   @Test
   public void javabeanTester() {
-    JavaBeanTester.builder(ApplicationSession.class).loadData().test();
+    JavaBeanTester.builder(ApplicationSession.class).loadData().skip("creationTime", "lastAccessTime").test();
   }
 
 }


### PR DESCRIPTION
… conditions

It's not deterministic when this will fail.  It grabs a constructor and
happens to get string to use.  The string is not parsed by date and
fails.  Because of multithreading, this occasionally was working.  It's
more of a problem now as all data objects are allowed to call real
constructors (first occurrence) rather than default no-arg constructor.
Hence a bug in javabean-tester that will now need addressed.