### PR TITLE
Fixed session expire link by using the web-app parameter

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/attributes.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/attributes.jsp
@@ -46,7 +46,7 @@
 			<c:if test="${! empty session}">
 
 				<li id="delete">
-					<a href="<c:url value='/app/expire.htm'><c:param name='webapp' value='${app.name}' /><c:param name='sid' value='${param.sid}' /></c:url>">
+					<a href="<c:url value='/app/expire.htm'><c:param name='webapp' value='${param.webapp}' /><c:param name='sid' value='${param.sid}' /></c:url>">
 						<spring:message code="probe.jsp.sessionAttibutes.menu.destroy"/>
 					</a>
 				</li>


### PR DESCRIPTION
Currently, the session expire link will fail as the web-app parameter is missing. By using the ${param.webapp} the missing parameter will be added the the link will work.