### PR TITLE
Update messages_de.properties

### DIFF
--- a/web/src/main/webapp/WEB-INF/messages_de.properties
+++ b/web/src/main/webapp/WEB-INF/messages_de.properties
@@ -87,6 +87,14 @@ probe.jsp.connectors.wrk.stage.parse=Einlesen
 probe.jsp.connectors.wrk.stage.prepare=Vorbereitet
 probe.jsp.connectors.wrk.stage.service=Service
 
+probe.jsp.certificates.col.alias=Alias
+probe.jsp.certificates.col.dn=Eindeutiger Name (DN)
+probe.jsp.certificates.col.notBefore=Nicht vor dem
+probe.jsp.certificates.col.notAfter=Nicht nach dem
+probe.jsp.certificates.viewCertDetails=Details anzeigen [noch nicht umgesetzt]
+probe.jsp.certificates.keyStore=Schl\u00fcssel Speicher (Key Store)
+probe.jsp.certificates.trustStore=Vertrauens Speicher (Trust Store)
+
 probe.jsp.cluster.chart.requests=Anfragen werden alle {0} Sekunden aktualisiert.
 probe.jsp.cluster.chart.traffic=Datentransfer-Volumen in Bytes
 probe.jsp.cluster.h3.info=Clusterinformationen


### PR DESCRIPTION
Update german translation.

"Key Store" and "Trust Store" are used in german language too in case of certificate description.
Maybe it should not be translated?