### PR TITLE
Issue #733 Trace important user actions in log file

### DIFF
--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -14,6 +14,8 @@ package psiprobe.controllers.apps;
 import org.apache.catalina.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.controllers.ContextHandlerController;
@@ -29,23 +31,28 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AjaxReloadContextController extends ContextHandlerController {
 
-  /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
 
-  @Override
-  protected ModelAndView handleContext(String contextName, Context context,
-      HttpServletRequest request, HttpServletResponse response) throws Exception {
+ @Override
+ protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
+   HttpServletResponse response) throws Exception {
 
-    if (!request.getContextPath().equals(contextName) && context != null) {
-      try {
-        logger.info("{} requested RELOAD of {}", request.getRemoteAddr(), contextName);
-        context.reload();
-      } catch (Exception e) {
-        logger.error("Error during ajax request to RELOAD of '{}'", contextName, e);
-      }
-    }
-    return new ModelAndView(getViewName(), "available", context != null
-        && getContainerWrapper().getTomcatContainer().getAvailable(context));
+  if (!request.getContextPath().equals(contextName) && context != null) {
+   try {
+    logger.info("{} requested RELOAD of {}", request.getRemoteAddr(), contextName);
+    context.reload();
+    // Logging action
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String name = auth.getName(); // get username logger
+    logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+      + getMessageSourceAccessor().getMessage("probe.src.log.reload")  + " " + contextName);
+   } catch (Exception e) {
+    logger.error("Error during ajax request to RELOAD of '{}'", contextName, e);
+   }
   }
+  return new ModelAndView(getViewName(), "available",
+    context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -31,28 +31,28 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AjaxReloadContextController extends ContextHandlerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
 
- @Override
- protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
-   HttpServletResponse response) throws Exception {
+@Override
+protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
+        HttpServletResponse response) throws Exception {
 
-  if (!request.getContextPath().equals(contextName) && context != null) {
-   try {
-    logger.info("{} requested RELOAD of {}", request.getRemoteAddr(), contextName);
-    context.reload();
-    // Logging action
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String name = auth.getName(); // get username logger
-    logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
-      + getMessageSourceAccessor().getMessage("probe.src.log.reload")  + " " + contextName);
-   } catch (Exception e) {
-    logger.error("Error during ajax request to RELOAD of '{}'", contextName, e);
-   }
-  }
-  return new ModelAndView(getViewName(), "available",
-    context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
- }
+    if (!request.getContextPath().equals(contextName) && context != null) {
+        try {
+            logger.info("{} requested RELOAD of {}", request.getRemoteAddr(), contextName);
+            context.reload();
+            // Logging action
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            String name = auth.getName(); // get username logger
+            logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+                    + getMessageSourceAccessor().getMessage("probe.src.log.reload") + " " + contextName);
+        } catch (Exception e) {
+            logger.error("Error during ajax request to RELOAD of '{}'", contextName, e);
+        }
+    }
+    return new ModelAndView(getViewName(), "available",
+            context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -31,35 +31,35 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AjaxToggleContextController extends ContextHandlerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
 
- @Override
- protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
-   HttpServletResponse response) throws Exception {
+@Override
+protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
+        HttpServletResponse response) throws Exception {
 
-  if (!request.getContextPath().equals(contextName) && context != null) {
-   try {
-    // Logging action
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String name = auth.getName(); // get username logger
-    if (context.getState().isAvailable()) {
-     logger.info("{} requested STOP of {}", request.getRemoteAddr(), contextName);
-     getContainerWrapper().getTomcatContainer().stop(contextName);
-     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
-       + getMessageSourceAccessor().getMessage("probe.src.log.stop")  + " " + contextName);
-    } else {
-     logger.info("{} requested START of {}", request.getRemoteAddr(), contextName);
-     getContainerWrapper().getTomcatContainer().start(contextName);
-     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
-       + getMessageSourceAccessor().getMessage("probe.src.log.start")  + " " + contextName);
+    if (!request.getContextPath().equals(contextName) && context != null) {
+        try {
+            // Logging action
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            String name = auth.getName(); // get username logger
+            if (context.getState().isAvailable()) {
+                logger.info("{} requested STOP of {}", request.getRemoteAddr(), contextName);
+                getContainerWrapper().getTomcatContainer().stop(contextName);
+                logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+                        + getMessageSourceAccessor().getMessage("probe.src.log.stop") + " " + contextName);
+            } else {
+                logger.info("{} requested START of {}", request.getRemoteAddr(), contextName);
+                getContainerWrapper().getTomcatContainer().start(contextName);
+                logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+                        + getMessageSourceAccessor().getMessage("probe.src.log.start") + " " + contextName);
+            }
+        } catch (Exception e) {
+            logger.error("Error during ajax request to START/STOP of '{}'", contextName, e);
+        }
     }
-   } catch (Exception e) {
-    logger.error("Error during ajax request to START/STOP of '{}'", contextName, e);
-   }
-  }
-  return new ModelAndView(getViewName(), "available",
-    context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
- }
+    return new ModelAndView(getViewName(), "available",
+            context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -14,6 +14,8 @@ package psiprobe.controllers.apps;
 import org.apache.catalina.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.controllers.ContextHandlerController;
@@ -29,28 +31,35 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AjaxToggleContextController extends ContextHandlerController {
 
-  /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);
 
-  @Override
-  protected ModelAndView handleContext(String contextName, Context context,
-      HttpServletRequest request, HttpServletResponse response) throws Exception {
+ @Override
+ protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
+   HttpServletResponse response) throws Exception {
 
-    if (!request.getContextPath().equals(contextName) && context != null) {
-      try {
-        if (context.getState().isAvailable()) {
-          logger.info("{} requested STOP of {}", request.getRemoteAddr(), contextName);
-          getContainerWrapper().getTomcatContainer().stop(contextName);
-        } else {
-          logger.info("{} requested START of {}", request.getRemoteAddr(), contextName);
-          getContainerWrapper().getTomcatContainer().start(contextName);
-        }
-      } catch (Exception e) {
-        logger.error("Error during ajax request to START/STOP of '{}'", contextName, e);
-      }
+  if (!request.getContextPath().equals(contextName) && context != null) {
+   try {
+    // Logging action
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String name = auth.getName(); // get username logger
+    if (context.getState().isAvailable()) {
+     logger.info("{} requested STOP of {}", request.getRemoteAddr(), contextName);
+     getContainerWrapper().getTomcatContainer().stop(contextName);
+     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+       + getMessageSourceAccessor().getMessage("probe.src.log.stop")  + " " + contextName);
+    } else {
+     logger.info("{} requested START of {}", request.getRemoteAddr(), contextName);
+     getContainerWrapper().getTomcatContainer().start(contextName);
+     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+       + getMessageSourceAccessor().getMessage("probe.src.log.start")  + " " + contextName);
     }
-    return new ModelAndView(getViewName(), "available", context != null
-        && getContainerWrapper().getTomcatContainer().getAvailable(context));
+   } catch (Exception e) {
+    logger.error("Error during ajax request to START/STOP of '{}'", contextName, e);
+   }
   }
+  return new ModelAndView(getViewName(), "available",
+    context != null && getContainerWrapper().getTomcatContainer().getAvailable(context));
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
@@ -12,6 +12,10 @@
 package psiprobe.controllers.apps;
 
 import org.apache.catalina.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Reloads application context.
@@ -20,12 +24,21 @@ import org.apache.catalina.Context;
  */
 public class ReloadContextController extends NoSelfContextHandlerController {
 
-  @Override
-  protected void executeAction(String contextName) throws Exception {
-    Context context = getContainerWrapper().getTomcatContainer().findContext(contextName);
-    if (context != null) {
-      context.reload();
-    }
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
+
+ @Override
+ protected void executeAction(String contextName) throws Exception {
+  Context context = getContainerWrapper().getTomcatContainer().findContext(contextName);
+  if (context != null) {
+   context.reload();
+
+   // Logging action
+   Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+   String name = auth.getName(); // get username logger
+   logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + name
+     + getMessageSourceAccessor().getMessage("probe.src.log.reload") + contextName);
   }
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
@@ -24,21 +24,21 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class ReloadContextController extends NoSelfContextHandlerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
 
- @Override
- protected void executeAction(String contextName) throws Exception {
-  Context context = getContainerWrapper().getTomcatContainer().findContext(contextName);
-  if (context != null) {
-   context.reload();
+@Override
+protected void executeAction(String contextName) throws Exception {
+    Context context = getContainerWrapper().getTomcatContainer().findContext(contextName);
+    if (context != null) {
+        context.reload();
 
-   // Logging action
-   Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-   String name = auth.getName(); // get username logger
-   logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + name
-     + getMessageSourceAccessor().getMessage("probe.src.log.reload") + contextName);
-  }
- }
+        // Logging action
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String name = auth.getName(); // get username logger
+        logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + name
+                + getMessageSourceAccessor().getMessage("probe.src.log.reload") + contextName);
+    }
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
@@ -23,18 +23,18 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class StartContextController extends NoSelfContextHandlerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
 
- @Override
- protected void executeAction(String contextName) throws Exception {
-  getContainerWrapper().getTomcatContainer().start(contextName);
+@Override
+protected void executeAction(String contextName) throws Exception {
+    getContainerWrapper().getTomcatContainer().start(contextName);
 
-  // Logging action
-  Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-  String name = auth.getName(); // get username logger
-  logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " " 
-    + getMessageSourceAccessor().getMessage("probe.src.log.start")  + " " + contextName);
- }
+    // Logging action
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String name = auth.getName(); // get username logger
+    logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+            + getMessageSourceAccessor().getMessage("probe.src.log.start") + " " + contextName);
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
@@ -11,6 +11,11 @@
 
 package psiprobe.controllers.apps;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 /**
  * Starts a web application.
  *
@@ -18,9 +23,18 @@ package psiprobe.controllers.apps;
  */
 public class StartContextController extends NoSelfContextHandlerController {
 
-  @Override
-  protected void executeAction(String contextName) throws Exception {
-    getContainerWrapper().getTomcatContainer().start(contextName);
-  }
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);
+
+ @Override
+ protected void executeAction(String contextName) throws Exception {
+  getContainerWrapper().getTomcatContainer().start(contextName);
+
+  // Logging action
+  Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+  String name = auth.getName(); // get username logger
+  logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " " 
+    + getMessageSourceAccessor().getMessage("probe.src.log.start")  + " " + contextName);
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
@@ -23,18 +23,18 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class StopContextController extends NoSelfContextHandlerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(StopContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(StopContextController.class);
 
- @Override
- protected void executeAction(String contextName) throws Exception {
-  getContainerWrapper().getTomcatContainer().stop(contextName);
+@Override
+protected void executeAction(String contextName) throws Exception {
+    getContainerWrapper().getTomcatContainer().stop(contextName);
 
-  // Logging action
-  Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-  String name = auth.getName(); // get username logger
-  logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " " 
-    + getMessageSourceAccessor().getMessage("probe.src.log.stop")  + " " + contextName);
- }
+    // Logging action
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String name = auth.getName(); // get username logger
+    logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+            + getMessageSourceAccessor().getMessage("probe.src.log.stop") + " " + contextName);
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
@@ -11,6 +11,11 @@
 
 package psiprobe.controllers.apps;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 /**
  * Stops a web application.
  *
@@ -18,9 +23,18 @@ package psiprobe.controllers.apps;
  */
 public class StopContextController extends NoSelfContextHandlerController {
 
-  @Override
-  protected void executeAction(String contextName) throws Exception {
-    getContainerWrapper().getTomcatContainer().stop(contextName);
-  }
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(StopContextController.class);
+
+ @Override
+ protected void executeAction(String contextName) throws Exception {
+  getContainerWrapper().getTomcatContainer().stop(contextName);
+
+  // Logging action
+  Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+  String name = auth.getName(); // get username logger
+  logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " " 
+    + getMessageSourceAccessor().getMessage("probe.src.log.stop")  + " " + contextName);
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -45,156 +45,153 @@ import psiprobe.controllers.TomcatContainerController;
  */
 public class CopySingleFileController extends TomcatContainerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(CopySingleFileController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(CopySingleFileController.class);
 
- @Override
- protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
-   throws Exception {
+@Override
+protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+        throws Exception {
 
-  List<Context> apps;
-  try {
-   apps = getContainerWrapper().getTomcatContainer().findContexts();
-  } catch (NullPointerException ex) {
-   throw new IllegalStateException(
-     "No container found for your server: " + getServletContext().getServerInfo(), ex);
-  }
-
-  List applications = new ArrayList();
-  for (Context appContext : apps) {
-   // check if this is not the ROOT webapp
-   if (appContext.getName() != null && appContext.getName().trim().length() > 0) {
-    Map<String, String> app = new HashMap<String, String>();
-    app.put("value", appContext.getName());
-    app.put("label", appContext.getName());
-    applications.add(app);
-   }
-  }
-  request.setAttribute("apps", applications);
-
-  if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
-
-   File tmpFile = null;
-   String contextName = null;
-   String where = null;
-   boolean reload = false;
-   boolean discard = false;
-
-   // parse multipart request and extract the file
-   FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-   ServletFileUpload upload = new ServletFileUpload(factory);
-   upload.setSizeMax(-1);
-   upload.setHeaderEncoding("UTF8");
-   try {
-    List<FileItem> fileItems = upload.parseRequest(request);
-    for (FileItem fi : fileItems) {
-     if (!fi.isFormField()) {
-      if (fi.getName() != null && fi.getName().length() > 0) {
-       tmpFile = new File(System.getProperty("java.io.tmpdir"),
-         FilenameUtils.getName(fi.getName()));
-       fi.write(tmpFile);
-      }
-     } else if ("context".equals(fi.getFieldName())) {
-      contextName = fi.getString();
-     } else if ("where".equals(fi.getFieldName())) {
-      where = fi.getString();
-     } else if ("reload".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-      reload = true;
-     } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-      discard = true;
-     }
-    }
-   } catch (Exception e) {
-    logger.error("Could not process file upload", e);
-    request.setAttribute("errorMessage", getMessageSourceAccessor()
-      .getMessage("probe.src.deploy.file.uploadfailure", new Object[] { e.getMessage() }));
-    if (tmpFile != null && tmpFile.exists()) {
-     tmpFile.delete();
-    }
-    tmpFile = null;
-   }
-
-   String errMsg = null;
-
-   if (tmpFile != null) {
+    List<Context> apps;
     try {
-     if (tmpFile.getName() != null && tmpFile.getName().trim().length() > 0) {
-
-      contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
-
-      String visibleContextName = "".equals(contextName) ? "/" : contextName;
-      request.setAttribute("contextName", visibleContextName);
-
-      // Check if context is already deployed
-      if (getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
-
-       File destFile = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
-         contextName + where);
-       // Checks if the destination path exists
-
-       if (destFile.exists()) {
-        if (!destFile.getAbsolutePath().contains("..")) {
-         // Copy the file overwriting it if it
-         // already exists
-         FileUtils.copyFileToDirectory(tmpFile, destFile);
-
-         request.setAttribute("successFile", Boolean.TRUE);
-         // Logging action
-         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-         String name = auth.getName(); // get username logger
-         logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
-           + name + " "
-           + getMessageSourceAccessor().getMessage("probe.src.log.copyfile")  + " "
-           + contextName);
-         Context context = getContainerWrapper().getTomcatContainer()
-           .findContext(contextName);
-         // Checks if DISCARD "work" directory is
-         // selected
-         if (discard) {
-          getContainerWrapper().getTomcatContainer().discardWorkDir(context);
-          logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
-            + name + " "
-            + getMessageSourceAccessor().getMessage("probe.src.log.discardwork")  + " "
-            + contextName);
-         }
-         // Checks if RELOAD option is selected
-         if (reload) {
-
-          if (context != null) {
-           context.reload();
-           request.setAttribute("reloadContext", Boolean.TRUE);
-           logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
-             + name + " "
-             + getMessageSourceAccessor().getMessage("probe.src.log.reload")  + " "
-             + contextName);
-          }
-         }
-        } else {
-         errMsg = getMessageSourceAccessor()
-           .getMessage("probe.src.deploy.file.pathNotValid");
-        }
-       } else {
-        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notPath");
-       }
-      } else {
-       errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notExists",
-         new Object[] { visibleContextName });
-      }
-     } else {
-      errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notFile.failure");
-     }
-    } catch (Exception e) {
-     errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.failure",
-       new Object[] { e.getMessage() });
-     logger.error("Tomcat throw an exception when trying to deploy", e);
-    } finally {
-     if (errMsg != null) {
-      request.setAttribute("errorMessage", errMsg);
-     }
-     tmpFile.delete();
+        apps = getContainerWrapper().getTomcatContainer().findContexts();
+    } catch (NullPointerException ex) {
+        throw new IllegalStateException("No container found for your server: " + getServletContext().getServerInfo(),
+                ex);
     }
-   }
-  }
-  return new ModelAndView(new InternalResourceView(getViewName()));
- }
+
+    List applications = new ArrayList();
+    for (Context appContext : apps) {
+        // check if this is not the ROOT webapp
+        if (appContext.getName() != null && appContext.getName().trim().length() > 0) {
+            Map<String, String> app = new HashMap<String, String>();
+            app.put("value", appContext.getName());
+            app.put("label", appContext.getName());
+            applications.add(app);
+        }
+    }
+    request.setAttribute("apps", applications);
+
+    if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
+
+        File tmpFile = null;
+        String contextName = null;
+        String where = null;
+        boolean reload = false;
+        boolean discard = false;
+
+        // parse multipart request and extract the file
+        FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
+        ServletFileUpload upload = new ServletFileUpload(factory);
+        upload.setSizeMax(-1);
+        upload.setHeaderEncoding("UTF8");
+        try {
+            List<FileItem> fileItems = upload.parseRequest(request);
+            for (FileItem fi : fileItems) {
+                if (!fi.isFormField()) {
+                    if (fi.getName() != null && fi.getName().length() > 0) {
+                        tmpFile = new File(System.getProperty("java.io.tmpdir"), FilenameUtils.getName(fi.getName()));
+                        fi.write(tmpFile);
+                    }
+                } else if ("context".equals(fi.getFieldName())) {
+                    contextName = fi.getString();
+                } else if ("where".equals(fi.getFieldName())) {
+                    where = fi.getString();
+                } else if ("reload".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+                    reload = true;
+                } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+                    discard = true;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Could not process file upload", e);
+            request.setAttribute("errorMessage", getMessageSourceAccessor()
+                    .getMessage("probe.src.deploy.file.uploadfailure", new Object[] { e.getMessage() }));
+            if (tmpFile != null && tmpFile.exists()) {
+                tmpFile.delete();
+            }
+            tmpFile = null;
+        }
+
+        String errMsg = null;
+
+        if (tmpFile != null) {
+            try {
+                if (tmpFile.getName() != null && tmpFile.getName().trim().length() > 0) {
+
+                    contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
+
+                    String visibleContextName = "".equals(contextName) ? "/" : contextName;
+                    request.setAttribute("contextName", visibleContextName);
+
+                    // Check if context is already deployed
+                    if (getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
+
+                        File destFile = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
+                                contextName + where);
+                        // Checks if the destination path exists
+
+                        if (destFile.exists()) {
+                            if (!destFile.getAbsolutePath().contains("..")) {
+                                // Copy the file overwriting it if it
+                                // already exists
+                                FileUtils.copyFileToDirectory(tmpFile, destFile);
+
+                                request.setAttribute("successFile", Boolean.TRUE);
+                                // Logging action
+                                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                                String name = auth.getName(); // get username
+                                                              // logger
+                                logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name
+                                        + " " + getMessageSourceAccessor().getMessage("probe.src.log.copyfile") + " "
+                                        + contextName);
+                                Context context = getContainerWrapper().getTomcatContainer().findContext(contextName);
+                                // Checks if DISCARD "work" directory is
+                                // selected
+                                if (discard) {
+                                    getContainerWrapper().getTomcatContainer().discardWorkDir(context);
+                                    logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+                                            + name + " "
+                                            + getMessageSourceAccessor().getMessage("probe.src.log.discardwork") + " "
+                                            + contextName);
+                                }
+                                // Checks if RELOAD option is selected
+                                if (reload) {
+
+                                    if (context != null) {
+                                        context.reload();
+                                        request.setAttribute("reloadContext", Boolean.TRUE);
+                                        logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username")
+                                                + " " + name + " "
+                                                + getMessageSourceAccessor().getMessage("probe.src.log.reload") + " "
+                                                + contextName);
+                                    }
+                                }
+                            } else {
+                                errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.pathNotValid");
+                            }
+                        } else {
+                            errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notPath");
+                        }
+                    } else {
+                        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notExists",
+                                new Object[] { visibleContextName });
+                    }
+                } else {
+                    errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notFile.failure");
+                }
+            } catch (Exception e) {
+                errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.failure",
+                        new Object[] { e.getMessage() });
+                logger.error("Tomcat throw an exception when trying to deploy", e);
+            } finally {
+                if (errMsg != null) {
+                    request.setAttribute("errorMessage", errMsg);
+                }
+                tmpFile.delete();
+            }
+        }
+    }
+    return new ModelAndView(new InternalResourceView(getViewName()));
+}
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -31,6 +31,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
@@ -43,141 +45,156 @@ import psiprobe.controllers.TomcatContainerController;
  */
 public class CopySingleFileController extends TomcatContainerController {
 
-	/** The Constant logger. */
-	private static final Logger logger = LoggerFactory.getLogger(CopySingleFileController.class);
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(CopySingleFileController.class);
 
-	@Override
-	protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
-			throws Exception {
+ @Override
+ protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+   throws Exception {
 
-		List<Context> apps;
-		try {
-			apps = getContainerWrapper().getTomcatContainer().findContexts();
-		} catch (NullPointerException ex) {
-			throw new IllegalStateException(
-					"No container found for your server: " + getServletContext().getServerInfo(), ex);
-		}
+  List<Context> apps;
+  try {
+   apps = getContainerWrapper().getTomcatContainer().findContexts();
+  } catch (NullPointerException ex) {
+   throw new IllegalStateException(
+     "No container found for your server: " + getServletContext().getServerInfo(), ex);
+  }
 
-		List applications = new ArrayList();
-		for (Context appContext : apps) {
-			// check if this is not the ROOT webapp
-			if (appContext.getName() != null && appContext.getName().trim().length() > 0) {
-				Map<String, String> app = new HashMap<String, String>();
-				app.put("value", appContext.getName());
-				app.put("label", appContext.getName());
-				applications.add(app);
-			}
-		}
-		request.setAttribute("apps", applications);
+  List applications = new ArrayList();
+  for (Context appContext : apps) {
+   // check if this is not the ROOT webapp
+   if (appContext.getName() != null && appContext.getName().trim().length() > 0) {
+    Map<String, String> app = new HashMap<String, String>();
+    app.put("value", appContext.getName());
+    app.put("label", appContext.getName());
+    applications.add(app);
+   }
+  }
+  request.setAttribute("apps", applications);
 
-		if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
+  if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
 
-			File tmpFile = null;
-			String contextName = null;
-			String where = null;
-			boolean reload = false;
-			boolean discard = false;
+   File tmpFile = null;
+   String contextName = null;
+   String where = null;
+   boolean reload = false;
+   boolean discard = false;
 
-			// parse multipart request and extract the file
-			FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-			ServletFileUpload upload = new ServletFileUpload(factory);
-			upload.setSizeMax(-1);
-			upload.setHeaderEncoding("UTF8");
-			try {
-				List<FileItem> fileItems = upload.parseRequest(request);
-				for (FileItem fi : fileItems) {
-					if (!fi.isFormField()) {
-						if (fi.getName() != null && fi.getName().length() > 0) {
-							tmpFile = new File(System.getProperty("java.io.tmpdir"),
-									FilenameUtils.getName(fi.getName()));
-							fi.write(tmpFile);
-						}
-					} else if ("context".equals(fi.getFieldName())) {
-						contextName = fi.getString();
-					} else if ("where".equals(fi.getFieldName())) {
-						where = fi.getString();
-					} else if ("reload".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-						reload = true;
-					} else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-						discard = true;
-					}
-				}
-			} catch (Exception e) {
-				logger.error("Could not process file upload", e);
-				request.setAttribute("errorMessage", getMessageSourceAccessor()
-						.getMessage("probe.src.deploy.file.uploadfailure", new Object[] { e.getMessage() }));
-				if (tmpFile != null && tmpFile.exists()) {
-					tmpFile.delete();
-				}
-				tmpFile = null;
-			}
+   // parse multipart request and extract the file
+   FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
+   ServletFileUpload upload = new ServletFileUpload(factory);
+   upload.setSizeMax(-1);
+   upload.setHeaderEncoding("UTF8");
+   try {
+    List<FileItem> fileItems = upload.parseRequest(request);
+    for (FileItem fi : fileItems) {
+     if (!fi.isFormField()) {
+      if (fi.getName() != null && fi.getName().length() > 0) {
+       tmpFile = new File(System.getProperty("java.io.tmpdir"),
+         FilenameUtils.getName(fi.getName()));
+       fi.write(tmpFile);
+      }
+     } else if ("context".equals(fi.getFieldName())) {
+      contextName = fi.getString();
+     } else if ("where".equals(fi.getFieldName())) {
+      where = fi.getString();
+     } else if ("reload".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+      reload = true;
+     } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+      discard = true;
+     }
+    }
+   } catch (Exception e) {
+    logger.error("Could not process file upload", e);
+    request.setAttribute("errorMessage", getMessageSourceAccessor()
+      .getMessage("probe.src.deploy.file.uploadfailure", new Object[] { e.getMessage() }));
+    if (tmpFile != null && tmpFile.exists()) {
+     tmpFile.delete();
+    }
+    tmpFile = null;
+   }
 
-			String errMsg = null;
+   String errMsg = null;
 
-			if (tmpFile != null) {
-				try {
-					if (tmpFile.getName() != null && tmpFile.getName().trim().length() > 0) {
+   if (tmpFile != null) {
+    try {
+     if (tmpFile.getName() != null && tmpFile.getName().trim().length() > 0) {
 
-						contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
+      contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
 
-						String visibleContextName = "".equals(contextName) ? "/" : contextName;
-						request.setAttribute("contextName", visibleContextName);
+      String visibleContextName = "".equals(contextName) ? "/" : contextName;
+      request.setAttribute("contextName", visibleContextName);
 
-						// Check if context is already deployed
-						if (getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
+      // Check if context is already deployed
+      if (getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
 
-							File destFile = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
-									contextName + where);
-							// Checks if the destination path exists
+       File destFile = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
+         contextName + where);
+       // Checks if the destination path exists
 
-							if (destFile.exists()) {
-								if (!destFile.getAbsolutePath().contains("..")) {
-									// Copy the file overwriting it if it
-									// already exists
-									FileUtils.copyFileToDirectory(tmpFile, destFile);
+       if (destFile.exists()) {
+        if (!destFile.getAbsolutePath().contains("..")) {
+         // Copy the file overwriting it if it
+         // already exists
+         FileUtils.copyFileToDirectory(tmpFile, destFile);
 
-									request.setAttribute("successFile", Boolean.TRUE);
-									Context context = getContainerWrapper().getTomcatContainer()
-											.findContext(contextName);
-									// Checks if DISCARD "work" directory is
-									// selected
-									if (discard) {
-										getContainerWrapper().getTomcatContainer().discardWorkDir(context);
-									}
-									// Checks if RELOAD option is selected
-									if (reload) {
+         request.setAttribute("successFile", Boolean.TRUE);
+         // Logging action
+         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+         String name = auth.getName(); // get username logger
+         logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+           + name + " "
+           + getMessageSourceAccessor().getMessage("probe.src.log.copyfile")  + " "
+           + contextName);
+         Context context = getContainerWrapper().getTomcatContainer()
+           .findContext(contextName);
+         // Checks if DISCARD "work" directory is
+         // selected
+         if (discard) {
+          getContainerWrapper().getTomcatContainer().discardWorkDir(context);
+          logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+            + name + " "
+            + getMessageSourceAccessor().getMessage("probe.src.log.discardwork")  + " "
+            + contextName);
+         }
+         // Checks if RELOAD option is selected
+         if (reload) {
 
-										if (context != null) {
-											context.reload();
-											request.setAttribute("reloadContext", Boolean.TRUE);
-										}
-									}
-								} else {
-									errMsg = getMessageSourceAccessor()
-											.getMessage("probe.src.deploy.file.pathNotValid");
-								}
-							} else {
-								errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notPath");
-							}
-						} else {
-							errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notExists",
-									new Object[] { visibleContextName });
-						}
-					} else {
-						errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notFile.failure");
-					}
-				} catch (Exception e) {
-					errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.failure",
-							new Object[] { e.getMessage() });
-					logger.error("Tomcat throw an exception when trying to deploy", e);
-				} finally {
-					if (errMsg != null) {
-						request.setAttribute("errorMessage", errMsg);
-					}
-					tmpFile.delete();
-				}
-			}
-		}
-		return new ModelAndView(new InternalResourceView(getViewName()));
-	}
+          if (context != null) {
+           context.reload();
+           request.setAttribute("reloadContext", Boolean.TRUE);
+           logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+             + name + " "
+             + getMessageSourceAccessor().getMessage("probe.src.log.reload")  + " "
+             + contextName);
+          }
+         }
+        } else {
+         errMsg = getMessageSourceAccessor()
+           .getMessage("probe.src.deploy.file.pathNotValid");
+        }
+       } else {
+        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notPath");
+       }
+      } else {
+       errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notExists",
+         new Object[] { visibleContextName });
+      }
+     } else {
+      errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.notFile.failure");
+     }
+    } catch (Exception e) {
+     errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.file.failure",
+       new Object[] { e.getMessage() });
+     logger.error("Tomcat throw an exception when trying to deploy", e);
+    } finally {
+     if (errMsg != null) {
+      request.setAttribute("errorMessage", errMsg);
+     }
+     tmpFile.delete();
+    }
+   }
+  }
+  return new ModelAndView(new InternalResourceView(getViewName()));
+ }
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
@@ -29,33 +29,32 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class DeployContextController extends TomcatContainerController {
 
- @Override
- public ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
-   throws Exception {
+@Override
+public ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-  String contextName = ServletRequestUtils.getStringParameter(request, "context", null);
+    String contextName = ServletRequestUtils.getStringParameter(request, "context", null);
 
-  if (contextName != null) {
-   try {
-    if (getContainerWrapper().getTomcatContainer().installContext(contextName)) {
-     request.setAttribute("successMessage", getMessageSourceAccessor()
-       .getMessage("probe.src.deploy.context.success", new Object[] { contextName }));
-     // Logging action
-     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-     String name = auth.getName(); // get username logger
-     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
-       + getMessageSourceAccessor().getMessage("probe.src.log.deploycontext") + contextName);
-    } else {
-     request.setAttribute("errorMessage", getMessageSourceAccessor()
-       .getMessage("probe.src.deploy.context.failure", new Object[] { contextName }));
+    if (contextName != null) {
+        try {
+            if (getContainerWrapper().getTomcatContainer().installContext(contextName)) {
+                request.setAttribute("successMessage", getMessageSourceAccessor()
+                        .getMessage("probe.src.deploy.context.success", new Object[] { contextName }));
+                // Logging action
+                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                String name = auth.getName(); // get username logger
+                logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+                        + getMessageSourceAccessor().getMessage("probe.src.log.deploycontext") + contextName);
+            } else {
+                request.setAttribute("errorMessage", getMessageSourceAccessor()
+                        .getMessage("probe.src.deploy.context.failure", new Object[] { contextName }));
+            }
+        } catch (Exception e) {
+            request.setAttribute("errorMessage", e.getMessage());
+            logger.trace("", e);
+        }
     }
-   } catch (Exception e) {
-    request.setAttribute("errorMessage", e.getMessage());
-    logger.trace("", e);
-   }
-  }
 
-  return new ModelAndView(new InternalResourceView(getViewName()));
- }
+    return new ModelAndView(new InternalResourceView(getViewName()));
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
@@ -11,6 +11,8 @@
 
 package psiprobe.controllers.deploy;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
@@ -27,32 +29,33 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class DeployContextController extends TomcatContainerController {
 
-  @Override
-  public ModelAndView handleRequestInternal(HttpServletRequest request,
-      HttpServletResponse response) throws Exception {
+ @Override
+ public ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+   throws Exception {
 
-    String contextName = ServletRequestUtils.getStringParameter(request, "context", null);
+  String contextName = ServletRequestUtils.getStringParameter(request, "context", null);
 
-    if (contextName != null) {
-      try {
-        if (getContainerWrapper().getTomcatContainer().installContext(contextName)) {
-          request.setAttribute(
-              "successMessage",
-              getMessageSourceAccessor().getMessage("probe.src.deploy.context.success",
-                  new Object[] {contextName}));
-        } else {
-          request.setAttribute(
-              "errorMessage",
-              getMessageSourceAccessor().getMessage("probe.src.deploy.context.failure",
-                  new Object[] {contextName}));
-        }
-      } catch (Exception e) {
-        request.setAttribute("errorMessage", e.getMessage());
-        logger.trace("", e);
-      }
+  if (contextName != null) {
+   try {
+    if (getContainerWrapper().getTomcatContainer().installContext(contextName)) {
+     request.setAttribute("successMessage", getMessageSourceAccessor()
+       .getMessage("probe.src.deploy.context.success", new Object[] { contextName }));
+     // Logging action
+     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+     String name = auth.getName(); // get username logger
+     logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+       + getMessageSourceAccessor().getMessage("probe.src.log.deploycontext") + contextName);
+    } else {
+     request.setAttribute("errorMessage", getMessageSourceAccessor()
+       .getMessage("probe.src.deploy.context.failure", new Object[] { contextName }));
     }
-
-    return new ModelAndView(new InternalResourceView(getViewName()));
+   } catch (Exception e) {
+    request.setAttribute("errorMessage", e.getMessage());
+    logger.trace("", e);
+   }
   }
+
+  return new ModelAndView(new InternalResourceView(getViewName()));
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -33,63 +33,66 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class UndeployContextController extends ContextHandlerController {
 
-  /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(UndeployContextController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(UndeployContextController.class);
 
-  /** The failure view name. */
-  private String failureViewName;
+/** The failure view name. */
+private String failureViewName;
 
-  /**
-   * Gets the failure view name.
-   *
-   * @return the failure view name
-   */
-  public String getFailureViewName() {
+/**
+ * Gets the failure view name.
+ *
+ * @return the failure view name
+ */
+public String getFailureViewName() {
     return failureViewName;
-  }
+}
 
-  /**
-   * Sets the failure view name.
-   *
-   * @param failureViewName the new failure view name
-   */
-  public void setFailureViewName(String failureViewName) {
+/**
+ * Sets the failure view name.
+ *
+ * @param failureViewName
+ *            the new failure view name
+ */
+public void setFailureViewName(String failureViewName) {
     this.failureViewName = failureViewName;
-  }
+}
 
-  @Override
-  protected ModelAndView handleContext(String contextName, Context context,
-      HttpServletRequest request, HttpServletResponse response) throws Exception {
+@Override
+protected ModelAndView handleContext(String contextName, Context context, HttpServletRequest request,
+        HttpServletResponse response) throws Exception {
     try {
-      if (request.getContextPath().equals(contextName)) {
-        throw new IllegalStateException(getMessageSourceAccessor().getMessage(
-            "probe.src.contextAction.cannotActOnSelf"));
-      }
+        if (request.getContextPath().equals(contextName)) {
+            throw new IllegalStateException(
+                    getMessageSourceAccessor().getMessage("probe.src.contextAction.cannotActOnSelf"));
+        }
 
-      getContainerWrapper().getTomcatContainer().remove(contextName);
-      //Logging action
-      Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-      String name = auth.getName(); //get username logger
-      logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") +  
-         " " + name  + " " + getMessageSourceAccessor().getMessage("probe.src.log.undeploy")  + " " + contextName);
+        getContainerWrapper().getTomcatContainer().remove(contextName);
+        // Logging action
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String name = auth.getName(); // get username logger
+        logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name + " "
+                + getMessageSourceAccessor().getMessage("probe.src.log.undeploy") + " " + contextName);
 
     } catch (Exception e) {
-      request.setAttribute("errorMessage", e.getMessage());
-      logger.error("Error during undeploy of '{}'", contextName, e);
-      return new ModelAndView(new InternalResourceView(getFailureViewName() == null ? getViewName()
-          : getFailureViewName()));
+        request.setAttribute("errorMessage", e.getMessage());
+        logger.error("Error during undeploy of '{}'", contextName, e);
+        return new ModelAndView(
+                new InternalResourceView(getFailureViewName() == null ? getViewName() : getFailureViewName()));
     }
     return new ModelAndView(new RedirectView(request.getContextPath() + getViewName()));
-  }
+}
 
-  /**
-   * Execute action.
-   *
-   * @param contextName the context name
-   * @throws Exception the exception
-   */
-  protected void executeAction(String contextName) throws Exception {
+/**
+ * Execute action.
+ *
+ * @param contextName
+ *            the context name
+ * @throws Exception
+ *             the exception
+ */
+protected void executeAction(String contextName) throws Exception {
     // Not Implemented
-  }
+}
 
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -14,6 +14,8 @@ package psiprobe.controllers.deploy;
 import org.apache.catalina.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.RedirectView;
@@ -65,6 +67,11 @@ public class UndeployContextController extends ContextHandlerController {
       }
 
       getContainerWrapper().getTomcatContainer().remove(contextName);
+      //Logging action
+      Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+      String name = auth.getName(); //get username logger
+      logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") +  
+         " " + name  + " " + getMessageSourceAccessor().getMessage("probe.src.log.undeploy")  + " " + contextName);
 
     } catch (Exception e) {
       request.setAttribute("errorMessage", e.getMessage());

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -22,6 +22,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
@@ -44,142 +46,145 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class UploadWarController extends TomcatContainerController {
 
-  /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(UploadWarController.class);
+ /** The Constant logger. */
+ private static final Logger logger = LoggerFactory.getLogger(UploadWarController.class);
 
-  @Override
-  protected ModelAndView handleRequestInternal(HttpServletRequest request,
-      HttpServletResponse response) throws Exception {
+ @Override
+ protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+   throws Exception {
 
-    if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
+  if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
 
-      File tmpWar = null;
-      String contextName = null;
-      boolean update = false;
-      boolean compile = false;
-      boolean discard = false;
+   File tmpWar = null;
+   String contextName = null;
+   boolean update = false;
+   boolean compile = false;
+   boolean discard = false;
 
-      // parse multipart request and extract the file
-      FileItemFactory factory =
-          new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-      ServletFileUpload upload = new ServletFileUpload(factory);
-      upload.setSizeMax(-1);
-      upload.setHeaderEncoding("UTF8");
-      try {
-        List<FileItem> fileItems = upload.parseRequest(request);
-        for (FileItem fi : fileItems) {
-          if (!fi.isFormField()) {
-            if (fi.getName() != null && fi.getName().length() > 0) {
-              tmpWar =
-                  new File(System.getProperty("java.io.tmpdir"),
-                      FilenameUtils.getName(fi.getName()));
-              fi.write(tmpWar);
-            }
-          } else if ("context".equals(fi.getFieldName())) {
-            contextName = fi.getString();
-          } else if ("update".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-            update = true;
-          } else if ("compile".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-            compile = true;
-          } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-            discard = true;
-          }
-        }
-      } catch (Exception e) {
-        logger.error("Could not process file upload", e);
-        request.setAttribute(
-            "errorMessage",
-            getMessageSourceAccessor().getMessage("probe.src.deploy.war.uploadfailure",
-                new Object[] {e.getMessage()}));
-        if (tmpWar != null && tmpWar.exists()) {
-          tmpWar.delete();
-        }
-        tmpWar = null;
+   // parse multipart request and extract the file
+   FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
+   ServletFileUpload upload = new ServletFileUpload(factory);
+   upload.setSizeMax(-1);
+   upload.setHeaderEncoding("UTF8");
+   try {
+    List<FileItem> fileItems = upload.parseRequest(request);
+    for (FileItem fi : fileItems) {
+     if (!fi.isFormField()) {
+      if (fi.getName() != null && fi.getName().length() > 0) {
+       tmpWar = new File(System.getProperty("java.io.tmpdir"),
+         FilenameUtils.getName(fi.getName()));
+       fi.write(tmpWar);
       }
-
-      String errMsg = null;
-
-      if (tmpWar != null) {
-        try {
-          if (tmpWar.getName().endsWith(".war")) {
-
-            if (contextName == null || contextName.length() == 0) {
-              String warFileName = tmpWar.getName().replaceAll("\\.war$", "");
-              contextName = "/" + warFileName;
-            }
-
-            contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
-
-            /*
-             * pass the name of the newly deployed context to the presentation layer using this name
-             * the presentation layer can render a url to view compilation details
-             */
-            String visibleContextName = "".equals(contextName) ? "/" : contextName;
-            request.setAttribute("contextName", visibleContextName);
-
-            if (update
-                && getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
-
-              logger.debug("updating {}: removing the old copy", contextName);
-              getContainerWrapper().getTomcatContainer().remove(contextName);
-            }
-
-            if (getContainerWrapper().getTomcatContainer().findContext(contextName) == null) {
-              // move the .war to tomcat application base dir
-              String destWarFilename =
-                  getContainerWrapper().getTomcatContainer().formatContextFilename(contextName);
-              File destWar =
-                  new File(getContainerWrapper().getTomcatContainer().getAppBase(), destWarFilename
-                      + ".war");
-
-              FileUtils.moveFile(tmpWar, destWar);
-
-              // let Tomcat know that the file is there
-              getContainerWrapper().getTomcatContainer().installWar(contextName,
-                  new URL("jar:" + destWar.toURI().toURL().toString() + "!/"));
-
-              Context ctx = getContainerWrapper().getTomcatContainer().findContext(contextName);
-              if (ctx == null) {
-                errMsg =
-                    getMessageSourceAccessor().getMessage("probe.src.deploy.war.notinstalled",
-                        new Object[] {visibleContextName});
-              } else {
-                request.setAttribute("success", Boolean.TRUE);
-                if (discard) {
-                  getContainerWrapper().getTomcatContainer().discardWorkDir(ctx);
-                }
-                if (compile) {
-                  Summary summary = new Summary();
-                  summary.setName(ctx.getName());
-                  getContainerWrapper().getTomcatContainer().listContextJsps(ctx, summary, true);
-                  request.getSession(true).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE,
-                      summary);
-                  request.setAttribute("compileSuccess", Boolean.TRUE);
-                }
-              }
-
-            } else {
-              errMsg =
-                  getMessageSourceAccessor().getMessage("probe.src.deploy.war.alreadyExists",
-                      new Object[] {visibleContextName});
-            }
-          } else {
-            errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notWar.failure");
-          }
-        } catch (Exception e) {
-          errMsg =
-              getMessageSourceAccessor().getMessage("probe.src.deploy.war.failure",
-                  new Object[] {e.getMessage()});
-          logger.error("Tomcat throw an exception when trying to deploy", e);
-        } finally {
-          if (errMsg != null) {
-            request.setAttribute("errorMessage", errMsg);
-          }
-          tmpWar.delete();
-        }
-      }
+     } else if ("context".equals(fi.getFieldName())) {
+      contextName = fi.getString();
+     } else if ("update".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+      update = true;
+     } else if ("compile".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+      compile = true;
+     } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+      discard = true;
+     }
     }
-    return new ModelAndView(new InternalResourceView(getViewName()));
+   } catch (Exception e) {
+    logger.error("Could not process file upload", e);
+    request.setAttribute("errorMessage", getMessageSourceAccessor()
+      .getMessage("probe.src.deploy.war.uploadfailure", new Object[] { e.getMessage() }));
+    if (tmpWar != null && tmpWar.exists()) {
+     tmpWar.delete();
+    }
+    tmpWar = null;
+   }
+
+   String errMsg = null;
+
+   if (tmpWar != null) {
+    try {
+     if (tmpWar.getName().endsWith(".war")) {
+
+      if (contextName == null || contextName.length() == 0) {
+       String warFileName = tmpWar.getName().replaceAll("\\.war$", "");
+       contextName = "/" + warFileName;
+      }
+
+      contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
+
+      /*
+       * pass the name of the newly deployed context to the
+       * presentation layer using this name the presentation
+       * layer can render a url to view compilation details
+       */
+      String visibleContextName = "".equals(contextName) ? "/" : contextName;
+      request.setAttribute("contextName", visibleContextName);
+
+      if (update && getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
+
+       logger.debug("updating {}: removing the old copy", contextName);
+       getContainerWrapper().getTomcatContainer().remove(contextName);
+      }
+
+      if (getContainerWrapper().getTomcatContainer().findContext(contextName) == null) {
+       // move the .war to tomcat application base dir
+       String destWarFilename = getContainerWrapper().getTomcatContainer()
+         .formatContextFilename(contextName);
+       File destWar = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
+         destWarFilename + ".war");
+
+       FileUtils.moveFile(tmpWar, destWar);
+
+       // let Tomcat know that the file is there
+       getContainerWrapper().getTomcatContainer().installWar(contextName,
+         new URL("jar:" + destWar.toURI().toURL().toString() + "!/"));
+
+       Context ctx = getContainerWrapper().getTomcatContainer().findContext(contextName);
+       if (ctx == null) {
+        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notinstalled",
+          new Object[] { visibleContextName });
+       } else {
+        request.setAttribute("success", Boolean.TRUE);
+        // Logging action
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String name = auth.getName(); // get username logger
+        logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+          + name + " "
+          + getMessageSourceAccessor().getMessage("probe.src.log.deploywar")  + " "
+          + contextName);
+        if (discard) {
+         getContainerWrapper().getTomcatContainer().discardWorkDir(ctx);
+         logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
+           + name + " "
+           + getMessageSourceAccessor().getMessage("probe.src.log.discardwork")  + " "
+           + contextName);
+        }
+        if (compile) {
+         Summary summary = new Summary();
+         summary.setName(ctx.getName());
+         getContainerWrapper().getTomcatContainer().listContextJsps(ctx, summary, true);
+         request.getSession(true).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE,
+           summary);
+         request.setAttribute("compileSuccess", Boolean.TRUE);
+        }
+       }
+
+      } else {
+       errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.alreadyExists",
+         new Object[] { visibleContextName });
+      }
+     } else {
+      errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notWar.failure");
+     }
+    } catch (Exception e) {
+     errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.failure",
+       new Object[] { e.getMessage() });
+     logger.error("Tomcat throw an exception when trying to deploy", e);
+    } finally {
+     if (errMsg != null) {
+      request.setAttribute("errorMessage", errMsg);
+     }
+     tmpWar.delete();
+    }
+   }
   }
+  return new ModelAndView(new InternalResourceView(getViewName()));
+ }
 
 }

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -46,145 +46,141 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class UploadWarController extends TomcatContainerController {
 
- /** The Constant logger. */
- private static final Logger logger = LoggerFactory.getLogger(UploadWarController.class);
+/** The Constant logger. */
+private static final Logger logger = LoggerFactory.getLogger(UploadWarController.class);
 
- @Override
- protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
-   throws Exception {
+@Override
+protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+        throws Exception {
 
-  if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
+    if (FileUploadBase.isMultipartContent(new ServletRequestContext(request))) {
 
-   File tmpWar = null;
-   String contextName = null;
-   boolean update = false;
-   boolean compile = false;
-   boolean discard = false;
+        File tmpWar = null;
+        String contextName = null;
+        boolean update = false;
+        boolean compile = false;
+        boolean discard = false;
 
-   // parse multipart request and extract the file
-   FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-   ServletFileUpload upload = new ServletFileUpload(factory);
-   upload.setSizeMax(-1);
-   upload.setHeaderEncoding("UTF8");
-   try {
-    List<FileItem> fileItems = upload.parseRequest(request);
-    for (FileItem fi : fileItems) {
-     if (!fi.isFormField()) {
-      if (fi.getName() != null && fi.getName().length() > 0) {
-       tmpWar = new File(System.getProperty("java.io.tmpdir"),
-         FilenameUtils.getName(fi.getName()));
-       fi.write(tmpWar);
-      }
-     } else if ("context".equals(fi.getFieldName())) {
-      contextName = fi.getString();
-     } else if ("update".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-      update = true;
-     } else if ("compile".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-      compile = true;
-     } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
-      discard = true;
-     }
-    }
-   } catch (Exception e) {
-    logger.error("Could not process file upload", e);
-    request.setAttribute("errorMessage", getMessageSourceAccessor()
-      .getMessage("probe.src.deploy.war.uploadfailure", new Object[] { e.getMessage() }));
-    if (tmpWar != null && tmpWar.exists()) {
-     tmpWar.delete();
-    }
-    tmpWar = null;
-   }
-
-   String errMsg = null;
-
-   if (tmpWar != null) {
-    try {
-     if (tmpWar.getName().endsWith(".war")) {
-
-      if (contextName == null || contextName.length() == 0) {
-       String warFileName = tmpWar.getName().replaceAll("\\.war$", "");
-       contextName = "/" + warFileName;
-      }
-
-      contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
-
-      /*
-       * pass the name of the newly deployed context to the
-       * presentation layer using this name the presentation
-       * layer can render a url to view compilation details
-       */
-      String visibleContextName = "".equals(contextName) ? "/" : contextName;
-      request.setAttribute("contextName", visibleContextName);
-
-      if (update && getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
-
-       logger.debug("updating {}: removing the old copy", contextName);
-       getContainerWrapper().getTomcatContainer().remove(contextName);
-      }
-
-      if (getContainerWrapper().getTomcatContainer().findContext(contextName) == null) {
-       // move the .war to tomcat application base dir
-       String destWarFilename = getContainerWrapper().getTomcatContainer()
-         .formatContextFilename(contextName);
-       File destWar = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
-         destWarFilename + ".war");
-
-       FileUtils.moveFile(tmpWar, destWar);
-
-       // let Tomcat know that the file is there
-       getContainerWrapper().getTomcatContainer().installWar(contextName,
-         new URL("jar:" + destWar.toURI().toURL().toString() + "!/"));
-
-       Context ctx = getContainerWrapper().getTomcatContainer().findContext(contextName);
-       if (ctx == null) {
-        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notinstalled",
-          new Object[] { visibleContextName });
-       } else {
-        request.setAttribute("success", Boolean.TRUE);
-        // Logging action
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String name = auth.getName(); // get username logger
-        logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
-          + name + " "
-          + getMessageSourceAccessor().getMessage("probe.src.log.deploywar")  + " "
-          + contextName);
-        if (discard) {
-         getContainerWrapper().getTomcatContainer().discardWorkDir(ctx);
-         logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " "
-           + name + " "
-           + getMessageSourceAccessor().getMessage("probe.src.log.discardwork")  + " "
-           + contextName);
+        // parse multipart request and extract the file
+        FileItemFactory factory = new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
+        ServletFileUpload upload = new ServletFileUpload(factory);
+        upload.setSizeMax(-1);
+        upload.setHeaderEncoding("UTF8");
+        try {
+            List<FileItem> fileItems = upload.parseRequest(request);
+            for (FileItem fi : fileItems) {
+                if (!fi.isFormField()) {
+                    if (fi.getName() != null && fi.getName().length() > 0) {
+                        tmpWar = new File(System.getProperty("java.io.tmpdir"), FilenameUtils.getName(fi.getName()));
+                        fi.write(tmpWar);
+                    }
+                } else if ("context".equals(fi.getFieldName())) {
+                    contextName = fi.getString();
+                } else if ("update".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+                    update = true;
+                } else if ("compile".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+                    compile = true;
+                } else if ("discard".equals(fi.getFieldName()) && "yes".equals(fi.getString())) {
+                    discard = true;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Could not process file upload", e);
+            request.setAttribute("errorMessage", getMessageSourceAccessor()
+                    .getMessage("probe.src.deploy.war.uploadfailure", new Object[] { e.getMessage() }));
+            if (tmpWar != null && tmpWar.exists()) {
+                tmpWar.delete();
+            }
+            tmpWar = null;
         }
-        if (compile) {
-         Summary summary = new Summary();
-         summary.setName(ctx.getName());
-         getContainerWrapper().getTomcatContainer().listContextJsps(ctx, summary, true);
-         request.getSession(true).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE,
-           summary);
-         request.setAttribute("compileSuccess", Boolean.TRUE);
-        }
-       }
 
-      } else {
-       errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.alreadyExists",
-         new Object[] { visibleContextName });
-      }
-     } else {
-      errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notWar.failure");
-     }
-    } catch (Exception e) {
-     errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.failure",
-       new Object[] { e.getMessage() });
-     logger.error("Tomcat throw an exception when trying to deploy", e);
-    } finally {
-     if (errMsg != null) {
-      request.setAttribute("errorMessage", errMsg);
-     }
-     tmpWar.delete();
+        String errMsg = null;
+
+        if (tmpWar != null) {
+            try {
+                if (tmpWar.getName().endsWith(".war")) {
+
+                    if (contextName == null || contextName.length() == 0) {
+                        String warFileName = tmpWar.getName().replaceAll("\\.war$", "");
+                        contextName = "/" + warFileName;
+                    }
+
+                    contextName = getContainerWrapper().getTomcatContainer().formatContextName(contextName);
+
+                    /*
+                     * pass the name of the newly deployed context to the
+                     * presentation layer using this name the presentation layer
+                     * can render a url to view compilation details
+                     */
+                    String visibleContextName = "".equals(contextName) ? "/" : contextName;
+                    request.setAttribute("contextName", visibleContextName);
+
+                    if (update && getContainerWrapper().getTomcatContainer().findContext(contextName) != null) {
+
+                        logger.debug("updating {}: removing the old copy", contextName);
+                        getContainerWrapper().getTomcatContainer().remove(contextName);
+                    }
+
+                    if (getContainerWrapper().getTomcatContainer().findContext(contextName) == null) {
+                        // move the .war to tomcat application base dir
+                        String destWarFilename = getContainerWrapper().getTomcatContainer()
+                                .formatContextFilename(contextName);
+                        File destWar = new File(getContainerWrapper().getTomcatContainer().getAppBase(),
+                                destWarFilename + ".war");
+
+                        FileUtils.moveFile(tmpWar, destWar);
+
+                        // let Tomcat know that the file is there
+                        getContainerWrapper().getTomcatContainer().installWar(contextName,
+                                new URL("jar:" + destWar.toURI().toURL().toString() + "!/"));
+
+                        Context ctx = getContainerWrapper().getTomcatContainer().findContext(contextName);
+                        if (ctx == null) {
+                            errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notinstalled",
+                                    new Object[] { visibleContextName });
+                        } else {
+                            request.setAttribute("success", Boolean.TRUE);
+                            // Logging action
+                            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                            String name = auth.getName(); // get username logger
+                            logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name
+                                    + " " + getMessageSourceAccessor().getMessage("probe.src.log.deploywar") + " "
+                                    + contextName);
+                            if (discard) {
+                                getContainerWrapper().getTomcatContainer().discardWorkDir(ctx);
+                                logger.info(getMessageSourceAccessor().getMessage("probe.src.log.username") + " " + name
+                                        + " " + getMessageSourceAccessor().getMessage("probe.src.log.discardwork") + " "
+                                        + contextName);
+                            }
+                            if (compile) {
+                                Summary summary = new Summary();
+                                summary.setName(ctx.getName());
+                                getContainerWrapper().getTomcatContainer().listContextJsps(ctx, summary, true);
+                                request.getSession(true).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE, summary);
+                                request.setAttribute("compileSuccess", Boolean.TRUE);
+                            }
+                        }
+
+                    } else {
+                        errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.alreadyExists",
+                                new Object[] { visibleContextName });
+                    }
+                } else {
+                    errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.notWar.failure");
+                }
+            } catch (Exception e) {
+                errMsg = getMessageSourceAccessor().getMessage("probe.src.deploy.war.failure",
+                        new Object[] { e.getMessage() });
+                logger.error("Tomcat throw an exception when trying to deploy", e);
+            } finally {
+                if (errMsg != null) {
+                    request.setAttribute("errorMessage", errMsg);
+                }
+                tmpWar.delete();
+            }
+        }
     }
-   }
-  }
-  return new ModelAndView(new InternalResourceView(getViewName()));
- }
+    return new ModelAndView(new InternalResourceView(getViewName()));
+}
 
 }

--- a/web/src/main/webapp/WEB-INF/messages.properties
+++ b/web/src/main/webapp/WEB-INF/messages.properties
@@ -748,3 +748,13 @@ probe.src.stats.listener.memory.pool.flappingStart.body={0}The size of memory po
 
 probe.src.stats.listener.memory.pool.flappingStop.subject.infix=*
 probe.src.stats.listener.memory.pool.flappingStop.body.prefix=* This value is no longer flapping.  Messages have resumed.\n\n
+#Logging messages
+probe.src.log.username=User
+probe.src.log.undeploy=has undeployed the context
+probe.src.log.stop=has stopped the context
+probe.src.log.start=has started the context
+probe.src.log.reload=has reloaded the context
+probe.src.log.deploycontext=has deployed the context
+probe.src.log.deploywar=has deployed a war in the context
+probe.src.log.copyfile=has copied a file in the context
+probe.src.log.discardwork=has discarded the work directory in the context

--- a/web/src/main/webapp/WEB-INF/messages_de.properties
+++ b/web/src/main/webapp/WEB-INF/messages_de.properties
@@ -87,6 +87,14 @@ probe.jsp.connectors.wrk.stage.parse=Einlesen
 probe.jsp.connectors.wrk.stage.prepare=Vorbereitet
 probe.jsp.connectors.wrk.stage.service=Service
 
+probe.jsp.certificates.col.alias=Alias
+probe.jsp.certificates.col.dn=Eindeutiger Name (DN)
+probe.jsp.certificates.col.notBefore=Nicht vor dem
+probe.jsp.certificates.col.notAfter=Nicht nach dem
+probe.jsp.certificates.viewCertDetails=Details anzeigen [noch nicht umgesetzt]
+probe.jsp.certificates.keyStore=Schl\u00fcssel Speicher (Key Store)
+probe.jsp.certificates.trustStore=Vertrauens Speicher (Trust Store)
+
 probe.jsp.cluster.chart.requests=Anfragen werden alle {0} Sekunden aktualisiert.
 probe.jsp.cluster.chart.traffic=Datentransfer-Volumen in Bytes
 probe.jsp.cluster.h3.info=Clusterinformationen

--- a/web/src/main/webapp/WEB-INF/messages_es.properties
+++ b/web/src/main/webapp/WEB-INF/messages_es.properties
@@ -738,3 +738,14 @@ probe.src.stats.listener.memory.pool.flappingStart.body={0}El tama\u00f1o de la 
 
 probe.src.stats.listener.memory.pool.flappingStop.subject.infix=*
 probe.src.stats.listener.memory.pool.flappingStop.body.prefix=* Este valor ya no esta aleteando. Los mensajes ser\u00e1n reanudados.\n\n
+
+#Logging messages
+probe.src.log.username=Usuario 
+probe.src.log.undeploy=ha replegado el contexto
+probe.src.log.stop=ha parado el contexto
+probe.src.log.start=ha arrancado el contexto
+probe.src.log.reload=ha recargado el contexto
+probe.src.log.deploycontext=ha desplegado el contexto
+probe.src.log.deploywar=ha desplegado un war en el contexto
+probe.src.log.copyfile=ha copiado un fichero en el contexto
+probe.src.log.discardwork=ha descartado el directorio work del contexto 


### PR DESCRIPTION
Add tracing to probe.log with user and actions.

Only in important actions such as, deploy war, undeploy, start, stop, reload, copy files to context and discarding work directory when deploying or copying a file into a context.
