### PR TITLE
Update dependencies and revert slf4j/logback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ![psi-probe](src/site/resources/images/psi-probe-banner.jpg)
 
+[site](https://psi-probe.github.io/psi-probe/)
+
 ## Contributing ##
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for info on working on PSI Probe and sending patches.

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 			<dependency>
 				<groupId>org.jmockit</groupId>
 				<artifactId>jmockit</artifactId>
-				<version>1.22</version>
+				<version>1.24</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.0.1</version>
 					<configuration>
 						<archive>
 							<manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -254,12 +254,12 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>jcl-over-slf4j</artifactId>
-				<version>1.7.21</version>
+				<version>1.7.13</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>1.7.21</version>
+				<version>1.7.13</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.7</version>
+					<version>3.0.1</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 					</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
 				<plugin>
 					<groupId>org.owasp</groupId>
 					<artifactId>dependency-check-maven</artifactId>
-					<version>1.3.6</version>
+					<version>1.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>pl.project13.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<spring.version>4.2.6.RELEASE</spring.version>
+		<spring.version>4.3.0.RELEASE</spring.version>
 		<spring-security.version>4.1.0.RELEASE</spring-security.version>
 	</properties>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.1.7</version>
+				<version>1.1.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.oracle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
-							<version>6.18</version>
+							<version>6.19</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.3.1</version>
+				<version>1.3.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
 				<plugin>
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>4.1.0</version>
+					<version>4.2.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.7.6.201602180812</version>
+					<version>0.7.7.201606060606</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,11 +3,11 @@
     xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">
     <bannerLeft>
         <src>/images/psi-probe-banner.jpg</src>
-        <href>http://github.com/psi-probe/psi-probe</href>
+        <href>https://github.com/psi-probe/psi-probe</href>
     </bannerLeft>
     <bannerRight>
-        <src>http://tomcat.apache.org/images/tomcat.png</src>
-        <href>http://tomcat.apache.org/</href>
+        <src>https://tomcat.apache.org/images/tomcat.png</src>
+        <href>https://tomcat.apache.org/</href>
     </bannerRight>
     <skin>
         <groupId>org.apache.maven.skins</groupId>


### PR DESCRIPTION
Update all the dependencies, upgrade site to use more https, and revert slf4j/logback due to outstanding issues with newer versions we have not addressed yet.