### PR TITLE
Update main.css

### DIFF
--- a/web/src/main/webapp/css/classic/main.css
+++ b/web/src/main/webapp/css/classic/main.css
@@ -12,6 +12,7 @@
 BODY {
 	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 	line-height: 20px;
+	font-size: 75%;
 	color: #000000;
 	text-decoration: none;
 	background-color: #fff; /* this is an IE hack to enable :hover behavior */


### PR DESCRIPTION
Hi,

restore to font-size, to builds as used on 2.4.x version!

Reduce font-size to 75%. It is necessary, because font-size for different languages, for example german, will be displayed better, then with the latest commit from nning.

Thank you
Klaus.