### PR TITLE
[pom] Revert spring to 4.2.6 until we can figure out issue with 4.3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<spring.version>4.3.1.RELEASE</spring.version>
+		<!-- 4.3.x causes 405 post error due to what looks like invalid usage on our part -->
+		<spring.version>4.2.6.RELEASE</spring.version>
 		<spring-security.version>4.1.1.RELEASE</spring-security.version>
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
I have figured out issue with prototype being incorrectly configured in many cases where it should have been using GET.  As that will take more time to look and and correct, for now reverting back to 4.2.6 so users can continue working with library.