### PR TITLE
Attempt to prevent unexpected session creation

### DIFF
--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -159,7 +159,7 @@ public class UploadWarController extends TomcatContainerController {
                   Summary summary = new Summary();
                   summary.setName(ctx.getName());
                   getContainerWrapper().getTomcatContainer().listContextJsps(ctx, summary, true);
-                  request.getSession(true).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE,
+                  request.getSession(false).setAttribute(DisplayJspController.SUMMARY_ATTRIBUTE,
                       summary);
                   request.setAttribute("compileSuccess", Boolean.TRUE);
                 }

--- a/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
@@ -43,7 +43,7 @@ public class RecompileJspController extends ContextHandlerController {
   protected ModelAndView handleContext(String contextName, Context context,
       HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-    HttpSession session = request.getSession(true);
+    HttpSession session = request.getSession(false);
     Summary summary = (Summary) session.getAttribute(DisplayJspController.SUMMARY_ATTRIBUTE);
 
     if (request.getMethod().equalsIgnoreCase("post") && summary != null) {

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
@@ -48,7 +48,7 @@ public class ViewSourceController extends ContextHandlerController {
     String jspName = ServletRequestUtils.getStringParameter(request, "source", null);
     boolean highlight = ServletRequestUtils.getBooleanParameter(request, "highlight", true);
     Summary summary =
-        (Summary) (request.getSession() != null ? request.getSession().getAttribute(
+        (Summary) (request.getSession(false) != null ? request.getSession(false).getAttribute(
             DisplayJspController.SUMMARY_ATTRIBUTE) : null);
 
     if (jspName != null && summary != null && contextName.equals(summary.getName())) {

--- a/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
@@ -54,7 +54,7 @@ public class ListSessionsController extends ContextHandlerController {
     SessionSearchInfo searchInfo = new SessionSearchInfo();
     searchInfo.setSearchAction(StringUtils.trimToNull(ServletRequestUtils.getStringParameter(
         request, "searchAction", SessionSearchInfo.ACTION_NONE)));
-    HttpSession sess = request.getSession();
+    HttpSession sess = request.getSession(false);
 
     if (searchInfo.isApply()) {
       searchInfo.setSessionId(StringUtils.trimToNull(ServletRequestUtils.getStringParameter(

--- a/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
@@ -70,7 +70,7 @@ public class ExecuteSqlController extends ContextHandlerController {
 
     // store current option values and query history in a session attribute
 
-    HttpSession sess = request.getSession();
+    HttpSession sess = request.getSession(false);
     DataSourceTestInfo sessData =
         (DataSourceTestInfo) sess.getAttribute(DataSourceTestInfo.DS_TEST_SESS_ATTR);
 

--- a/web/src/main/webapp/WEB-INF/spring-probe-security.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-security.xml
@@ -86,4 +86,8 @@
 
 	<bean id="securityContextHolderAwareRequestFilter" class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter" />
 
+	<bean id="httpSessionRequestCache" class="org.springframework.security.web.savedrequest.HttpSessionRequestCache"> 
+		<property name="createSessionAllowed" value="false" /> 
+	</bean>
+
 </beans>


### PR DESCRIPTION
By default, we should not be allow random creation of session.  When we tried in the past to further secure the application we ran into issues with excess session creation.  This was part of the issue but not the full story.  This however is enough to ensure that if a session expires it isn't simply restored which could be sign of a security issue.