### PR TITLE
[pom] Upgrade to spring 4.3.1 and fix prototype/tagging issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <!-- 4.3.x causes 405 post error due to what looks like invalid usage on our part -->
-        <spring.version>4.2.6.RELEASE</spring.version>
+        <spring.version>4.3.1.RELEASE</spring.version>
         <spring-security.version>4.1.1.RELEASE</spring-security.version>
     </properties>
 

--- a/web/src/main/webapp/WEB-INF/jsp/appsummary.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appsummary.jsp
@@ -126,7 +126,7 @@
 					function updateAppInfo() {
 						new Ajax.Updater('runtimeAppInfo',
 						'<c:url value="/appruntimeinfo.ajax?${pageContext.request.queryString}"/>',
-						{asynchronous: false});
+						{method:'get', asynchronous: false});
 
 						// changing visibility of markup items that depend on an application status
 						if ($('r_appStatusUp')) {
@@ -288,8 +288,8 @@
 
 						imageUpdaters[0] = new Ajax.ImgUpdater('req_chart', '${probe:max(collectionPeriod, 5)}');
 						imageUpdaters[1] = new Ajax.ImgUpdater('avg_proc_time_chart', '${probe:max(collectionPeriod, 5)}');
-						new Ajax.PeriodicalUpdater('dd-req', '<c:url value="/appreqdetails.ajax"><c:param name="webapp" value="${app.name}" /></c:url>', {frequency: 3});
-						new Ajax.PeriodicalUpdater('dd-proc_time', '<c:url value="/appprocdetails.ajax"><c:param name="webapp" value="${app.name}" /></c:url>', {frequency: 3});
+						new Ajax.PeriodicalUpdater('dd-req', '<c:url value="/appreqdetails.ajax"><c:param name="webapp" value="${app.name}" /></c:url>', {method:'get', frequency: 3});
+						new Ajax.PeriodicalUpdater('dd-proc_time', '<c:url value="/appprocdetails.ajax"><c:param name="webapp" value="${app.name}" /></c:url>', {method:'get', frequency: 3});
 					</script>
 				</c:if>
 

--- a/web/src/main/webapp/WEB-INF/jsp/cluster.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/cluster.jsp
@@ -137,7 +137,7 @@
 					new Ajax.ImgUpdater('cl_requests', '${probe:max(collectionPeriod, 5)}');
 					new Ajax.PeriodicalUpdater('dd_traffic', '<c:url value="/cluster/traffic.ajax"/>', {frequency: 3});
 					new Ajax.PeriodicalUpdater('dd_requests', '<c:url value="/cluster/requests.ajax"/>', {frequency: 3});
-					new Ajax.PeriodicalUpdater('members', '<c:url value="/cluster/members.ajax"/>?<%=request.getQueryString()%>', {frequency: 3});
+					new Ajax.PeriodicalUpdater('members', '<c:url value="/cluster/members.ajax"/>?<%=request.getQueryString()%>', {method:'get',frequency: 3});
 				</script>
 
 			</c:otherwise>

--- a/web/src/main/webapp/WEB-INF/jsp/follow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/follow.jsp
@@ -17,7 +17,7 @@
 
 <%--
 	Log file view. The view is a simple markup that gets updated via AJAX calls. Top menu does not go to the server but
-	rather does DOM tricks to modify content appearence.
+	rather does DOM tricks to modify content appearance.
 
 	Author: Vlad Ilyushchenko.
 --%>
@@ -230,9 +230,10 @@
 			}
 
 			var infoUpdater = new Ajax.PeriodicalUpdater('info', '<c:url value="/logs/ff_info.ajax"/>', {
+				method:'get',
 				parameters: {
 					logType: '${probe:escapeJS(log.logType)}',
-					webapp: '${webapp}',
+					webapp: '${param.webapp}',
 					context: '${log.context}',
 					root: '${log.root}',
 					logName: '${probe:escapeJS(log.name)}',
@@ -252,9 +253,10 @@
 
 			function followLog(currentLogSize) {
 				new Ajax.Updater(file_content_div, '<c:url value="/logs/follow.ajax"/>', {
+					method:'get',
 					parameters: {
 						logType: '${probe:escapeJS(log.logType)}',
-						webapp: '${webapp}',
+						webapp: '${param.webapp}',
 						context: '${log.context}',
 						root: '${log.root}',
 						logName: '${probe:escapeJS(log.name)}',

--- a/web/src/main/webapp/WEB-INF/jsp/memory.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/memory.jsp
@@ -143,7 +143,7 @@
 					}
 				}
 
-				new Ajax.PeriodicalUpdater('memoryPools', '<c:url value="/memory.ajax"/>?<%=request.getQueryString()%>', {frequency: 5});
+				new Ajax.PeriodicalUpdater('memoryPools', '<c:url value="/memory.ajax"/>?<%=request.getQueryString()%>', {method:'get', frequency: 5});
 
 			</script>
 		</c:otherwise>

--- a/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
@@ -76,7 +76,7 @@
 		<script type="text/javascript">
 			new Ajax.PeriodicalUpdater('servletListContainer',
 			'<c:url value="/servlets.ajax?${pageContext.request.queryString}"/>',
-			{frequency: 5});
+			{method:'get', frequency: 5});
 		</script>
 
 	</body>


### PR DESCRIPTION
One tag issue had wrong property value and prototype was configured to use post where get should have been used.  This caused the 405 errors users exprienced when tryinging to upgrade to spring 4.3.1.  Now we are going back to 4.3.1 and it's working.  Fixes #754 