### PR TITLE
Add SIFT logback.xml for support of testing our SIFT logback logic

### DIFF
--- a/docs/logback-samples/sift-appender/README.md
+++ b/docs/logback-samples/sift-appender/README.md
@@ -1,0 +1,3 @@
+Logback Sift Appender Example
+
+- Logback 'logback.xml' has SIFT appender example for testing psi probe SIFT appender support.  Bundle with another webapp and ran alongside psi-probe in container.

--- a/docs/logback-samples/sift-appender/logback.xml
+++ b/docs/logback-samples/sift-appender/logback.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE project>
+<configuration scan="true" debug="false">
+
+  <appender name="PSI-PROBE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${probe.log.path}/probe.log</File>
+    <append>true</append>
+    <encoder>
+      <charset>utf-8</charset>
+      <pattern>%d{HH:mm:ss.SSS} %-5level {%thread} [%logger{40}] %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${probe.log.path}/archive/probe-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+      <maxHistory>10</maxHistory>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>20MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+    </rollingPolicy>
+  </appender>
+
+  <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <discriminator>
+      <key>userid</key>
+      <defaultValue>unknown</defaultValue>
+    </discriminator>
+    <sift>
+      <appender name="FILE-${userid}" class="ch.qos.logback.core.FileAppender">
+        <file>user-${userid}.log</file>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+          <pattern>%d{HH:mm:ss:SSS} | %-5level | %thread | %logger{20} | %msg%n%rEx</pattern>
+        </layout>
+      </appender>
+    </sift>
+  </appender>
+
+  <logger name="org.springframework.web.context.support" level="ERROR"/>
+  <logger name="org.springframework.beans.factory.support" level="ERROR"/>
+
+  <root level="INFO">
+    <appender-ref ref="PSI-PROBE"/>
+    <appender-ref ref="SIFT" />
+  </root>
+</configuration>


### PR DESCRIPTION
New directory called 'docs' with samples of items we might use for testing various scenerios.  First up the SIFT appender support I last used to get SIFT support fixed.  Worth keeping for reference.