### PR TITLE
[social] Remove author tags.  Everything is owned by psi probe unless…

### DIFF
--- a/core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -56,9 +56,6 @@ import javax.servlet.ServletContext;
 /**
  * Abstraction layer to implement some functionality, which is common between different container
  * adapters.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public abstract class AbstractTomcatContainer implements TomcatContainer {
 

--- a/core/src/main/java/psiprobe/AwtAppContextClassloaderListener.java
+++ b/core/src/main/java/psiprobe/AwtAppContextClassloaderListener.java
@@ -20,9 +20,6 @@ import javax.servlet.ServletContextListener;
 /**
  * Prevents a classloader leak as suggested by
  * <a href="https://cdivilly.wordpress.com/2012/04/23/permgen-memory-leak/">Colm Divilly</a>
- * 
- * @author diogosantana
- *
  */
 public class AwtAppContextClassloaderListener implements ServletContextListener {
 

--- a/core/src/main/java/psiprobe/ProbeServlet.java
+++ b/core/src/main/java/psiprobe/ProbeServlet.java
@@ -29,9 +29,6 @@ import javax.servlet.http.HttpServletResponse;
  * Main dispatcher servlet. Spring default dispatcher servlet had to be superceeded to handle
  * "privileged" application context features. The actual requirement is to capture passed Wrapper
  * instance into ContainerWrapperBean. Wrapper instance is our gateway to Tomcat.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ProbeServlet extends DispatcherServlet implements ContainerServlet {
 

--- a/core/src/main/java/psiprobe/TomcatContainer.java
+++ b/core/src/main/java/psiprobe/TomcatContainer.java
@@ -30,9 +30,6 @@ import javax.naming.NamingException;
 
 /**
  * Part of Tomcat container version abstraction layer.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public interface TomcatContainer {
 

--- a/core/src/main/java/psiprobe/Utils.java
+++ b/core/src/main/java/psiprobe/Utils.java
@@ -51,9 +51,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Misc. static helper methods.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Utils {
 

--- a/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
@@ -22,9 +22,6 @@ import java.lang.reflect.Field;
 
 /**
  * The Class BoneCpDatasourceAccessor.
- *
- * @author akhawatrah
- * @author Mark Lewis
  */
 public class BoneCpDatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/C3P0DatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/C3P0DatasourceAccessor.java
@@ -16,9 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * Abstraction layer for c3p0. Maps c3p0 datasource properties on our generic DataSourceInfo bean.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class C3P0DatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/ClusterWrapperBean.java
+++ b/core/src/main/java/psiprobe/beans/ClusterWrapperBean.java
@@ -27,8 +27,6 @@ import javax.management.ObjectName;
 
 /**
  * The Class ClusterWrapperBean.
- *
- * @author Vlad Ilyushchenko
  */
 public class ClusterWrapperBean {
 

--- a/core/src/main/java/psiprobe/beans/ContainerListenerBean.java
+++ b/core/src/main/java/psiprobe/beans/ContainerListenerBean.java
@@ -38,9 +38,6 @@ import javax.management.RuntimeOperationsException;
 /**
  * This class interfaces Tomcat JMX functionality to read connection status. The class essentially
  * provides and maintains the list of connection ThreadPools.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ContainerListenerBean implements NotificationListener {
 

--- a/core/src/main/java/psiprobe/beans/ContainerWrapperBean.java
+++ b/core/src/main/java/psiprobe/beans/ContainerWrapperBean.java
@@ -28,9 +28,6 @@ import java.util.Map;
  * application context is privileged Tomcat would always call servlet.setWrapper method on each
  * request. ContainerWrapperBean wires the passed wrapper to the relevant Tomcat container adapter
  * class, which in turn helps the Probe to interpret the wrapper.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ContainerWrapperBean {
 

--- a/core/src/main/java/psiprobe/beans/DatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/DatasourceAccessor.java
@@ -15,8 +15,6 @@ import psiprobe.model.DataSourceInfo;
 /**
  * Part of datasource type abstraction layer. Allows to extent Probe functionality to any kind of
  * datasources.
- * 
- * @author Vlad Ilyushchenko
  */
 public interface DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/DbcpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/DbcpDatasourceAccessor.java
@@ -16,9 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * DBCP datasource abstraction layer.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DbcpDatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/JBossResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/JBossResourceResolverBean.java
@@ -33,9 +33,6 @@ import javax.sql.DataSource;
 
 /**
  * An Adapter to convert information retrieved from JBoss JMX beans into internal resource model.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class JBossResourceResolverBean implements ResourceResolver {
 

--- a/core/src/main/java/psiprobe/beans/JvmMemoryInfoAccessorBean.java
+++ b/core/src/main/java/psiprobe/beans/JvmMemoryInfoAccessorBean.java
@@ -28,8 +28,6 @@ import javax.management.openmbean.CompositeDataSupport;
 
 /**
  * The Class JvmMemoryInfoAccessorBean.
- *
- * @author Vlad Ilyushchenko
  */
 public class JvmMemoryInfoAccessorBean {
 

--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -41,8 +41,6 @@ import java.util.List;
 
 /**
  * The Class LogResolverBean.
- *
- * @author Mark Lewis
  */
 public class LogResolverBean {
 

--- a/core/src/main/java/psiprobe/beans/OpenEjbManagedDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/OpenEjbManagedDatasourceAccessor.java
@@ -18,8 +18,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * Datasource accessor OpenEJB / TomEE.
- *
- * @author Dusan Jakub
  */
 public class OpenEjbManagedDatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/OracleDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/OracleDatasourceAccessor.java
@@ -31,9 +31,6 @@ import java.util.Properties;
  * tedious job of verifying whether the datasource has a record in the cache manager or not. The
  * pool information is subsequently retrieved from the relevant cache manager entry.
  * </p>
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class OracleDatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/OracleUcpDatasourceAssessor.java
+++ b/core/src/main/java/psiprobe/beans/OracleUcpDatasourceAssessor.java
@@ -16,9 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * Accesses an Oracle Universal Connection Pool (UCP) resource.
- * 
- * @author polaris.keith
- * @author Mark Lewis
  */
 public class OracleUcpDatasourceAssessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/ResourceResolver.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolver.java
@@ -23,10 +23,6 @@ import javax.sql.DataSource;
 /**
  * Interface of beans that retrieve information about "resources" of application server. Typically
  * those resources would be datasources.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public interface ResourceResolver {
 

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -32,11 +32,6 @@ import javax.sql.DataSource;
 
 /**
  * The Class ResourceResolverBean.
- *
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
- * @author Henry Caballero
  */
 public class ResourceResolverBean implements ResourceResolver {
 

--- a/core/src/main/java/psiprobe/beans/RuntimeInfoAccessorBean.java
+++ b/core/src/main/java/psiprobe/beans/RuntimeInfoAccessorBean.java
@@ -22,9 +22,6 @@ import javax.management.ObjectName;
 
 /**
  * The Class RuntimeInfoAccessorBean.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class RuntimeInfoAccessorBean {
 

--- a/core/src/main/java/psiprobe/beans/TomcatJdbcPoolDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/TomcatJdbcPoolDatasourceAccessor.java
@@ -16,9 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * Datasource accessor for tomcat.
- *
- * @author chenwang
- * @author Mark Lewis
  */
 public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/AbstractStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/AbstractStatsCollectorBean.java
@@ -23,10 +23,6 @@ import java.util.TreeMap;
 
 /**
  * The Class AbstractStatsCollectorBean.
- *
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public abstract class AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/AppStatsCollectorBean.java
@@ -25,9 +25,6 @@ import javax.servlet.ServletContext;
 
 /**
  * Collects application statistics.
- *
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class AppStatsCollectorBean extends AbstractStatsCollectorBean implements
     ServletContextAware {

--- a/core/src/main/java/psiprobe/beans/stats/collectors/ClusterStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/ClusterStatsCollectorBean.java
@@ -17,8 +17,6 @@ import psiprobe.model.jmx.Cluster;
 
 /**
  * The Class ClusterStatsCollectorBean.
- *
- * @author Vlad Ilyushchenko
  */
 public class ClusterStatsCollectorBean extends AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/ConnectorStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/ConnectorStatsCollectorBean.java
@@ -15,9 +15,6 @@ import psiprobe.model.Connector;
 
 /**
  * The Class ConnectorStatsCollectorBean.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ConnectorStatsCollectorBean extends AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/DatasourceStatsCollectorBean.java
@@ -19,8 +19,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * The Class DatasourceStatsCollectorBean.
- *
- * @author Mark Lewis
  */
 public class DatasourceStatsCollectorBean extends AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/JvmMemoryStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/JvmMemoryStatsCollectorBean.java
@@ -17,8 +17,6 @@ import java.util.List;
 
 /**
  * The Class JvmMemoryStatsCollectorBean.
- *
- * @author Vlad Ilyushchenko
  */
 public class JvmMemoryStatsCollectorBean extends AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/collectors/RuntimeStatsCollectorBean.java
+++ b/core/src/main/java/psiprobe/beans/stats/collectors/RuntimeStatsCollectorBean.java
@@ -15,9 +15,6 @@ import psiprobe.model.jmx.RuntimeInformation;
 
 /**
  * The Class RuntimeStatsCollectorBean.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class RuntimeStatsCollectorBean extends AbstractStatsCollectorBean {
 

--- a/core/src/main/java/psiprobe/beans/stats/listeners/AbstractStatsCollectionListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/AbstractStatsCollectionListener.java
@@ -19,8 +19,6 @@ import org.slf4j.LoggerFactory;
  * with that class is registered with a component using the component's
  * {@code addAbstractStatsCollectionListener} method. When the abstractStatsCollection event occurs,
  * that object's appropriate method is invoked.
- *
- * @author Mark Lewis
  */
 public abstract class AbstractStatsCollectionListener implements StatsCollectionListener {
 

--- a/core/src/main/java/psiprobe/beans/stats/listeners/FlapListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/FlapListener.java
@@ -21,7 +21,6 @@ import java.util.LinkedList;
  * component using the component's {@code addFlapListener} method. When the flap event occurs, that
  * object's appropriate method is invoked.
  *
- * @author Mark Lewis
  * @see <a href="http://nagios.sourceforge.net/docs/3_0/flapping.html">Detection and Handling of
  *      State Flapping (nagios)</a>
  */

--- a/core/src/main/java/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
@@ -25,8 +25,6 @@ import javax.mail.MessagingException;
  * processing a memoryPoolMailing event implements this interface, and the object created with that
  * class is registered with a component using the component's {@code addMemoryPoolMailingListener}
  * method. When the memoryPoolMailing event occurs, that object's appropriate method is invoked.
- *
- * @author Mark Lewis
  */
 public class MemoryPoolMailingListener extends FlapListener implements MessageSourceAware,
     InitializingBean {

--- a/core/src/main/java/psiprobe/beans/stats/listeners/StatsCollectionEvent.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/StatsCollectionEvent.java
@@ -14,8 +14,6 @@ import org.jfree.data.xy.XYDataItem;
 
 /**
  * The Class StatsCollectionEvent.
- *
- * @author Mark Lewis
  */
 public class StatsCollectionEvent {
 

--- a/core/src/main/java/psiprobe/beans/stats/listeners/StatsCollectionListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/StatsCollectionListener.java
@@ -15,8 +15,6 @@ package psiprobe.beans.stats.listeners;
  * processing a statsCollection event implements this interface, and the object created with that
  * class is registered with a component using the component's {@code addStatsCollectionListener}
  * method. When the statsCollection event occurs, that object's appropriate method is invoked.
- *
- * @author Mark Lewis
  */
 public interface StatsCollectionListener {
 

--- a/core/src/main/java/psiprobe/beans/stats/listeners/ThresholdListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/ThresholdListener.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
  * a threshold event implements this interface, and the object created with that class is registered
  * with a component using the component's {@code addThresholdListener} method. When the threshold
  * event occurs, that object's appropriate method is invoked.
- *
- * @author Mark Lewis
  */
 public abstract class ThresholdListener extends AbstractStatsCollectionListener {
 

--- a/core/src/main/java/psiprobe/beans/stats/providers/AbstractSeriesProvider.java
+++ b/core/src/main/java/psiprobe/beans/stats/providers/AbstractSeriesProvider.java
@@ -19,9 +19,6 @@ import java.util.List;
 
 /**
  * The Class AbstractSeriesProvider.
- *
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
  */
 public abstract class AbstractSeriesProvider implements SeriesProvider {
 

--- a/core/src/main/java/psiprobe/beans/stats/providers/ConnectorSeriesProvider.java
+++ b/core/src/main/java/psiprobe/beans/stats/providers/ConnectorSeriesProvider.java
@@ -22,8 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * The Class ConnectorSeriesProvider.
- *
- * @author Vlad Ilyushchenko
  */
 public class ConnectorSeriesProvider extends AbstractSeriesProvider {
 

--- a/core/src/main/java/psiprobe/beans/stats/providers/MultipleSeriesProvider.java
+++ b/core/src/main/java/psiprobe/beans/stats/providers/MultipleSeriesProvider.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletRequest;
  * or only "top" N ones can be retrieved. Determines top series by comparing max moving avg values.
  * Derrives legend entries from series names by removing the statNamePrefix. Ignores series param
  * (sp) and legend (s...l) request parameters.
- *
- * @author Andy Shapoval
  */
 public class MultipleSeriesProvider extends AbstractSeriesProvider {
 

--- a/core/src/main/java/psiprobe/beans/stats/providers/SeriesProvider.java
+++ b/core/src/main/java/psiprobe/beans/stats/providers/SeriesProvider.java
@@ -19,8 +19,6 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Classes implementing this interface can be wired up with RenderChartController to provide Series
  * data based on StatsCollection instance.
- *
- * @author Vlad Ilyushchenko
  */
 public interface SeriesProvider {
 

--- a/core/src/main/java/psiprobe/beans/stats/providers/StandardSeriesProvider.java
+++ b/core/src/main/java/psiprobe/beans/stats/providers/StandardSeriesProvider.java
@@ -24,8 +24,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * The Class StandardSeriesProvider.
- *
- * @author Vlad Ilyushchenko
  */
 public class StandardSeriesProvider extends AbstractSeriesProvider {
 

--- a/core/src/main/java/psiprobe/controllers/BeanToXmlController.java
+++ b/core/src/main/java/psiprobe/controllers/BeanToXmlController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class BeanToXmlController.
- *
- * @author Vlad Ilyushchenko
  */
 public class BeanToXmlController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/ContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/ContextHandlerController.java
@@ -21,9 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Base class for all controllers requiring "webapp" request parameter.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public abstract class ContextHandlerController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/DecoratorController.java
+++ b/core/src/main/java/psiprobe/controllers/DecoratorController.java
@@ -27,8 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class DecoratorController.
- *
- * @author Vlad Ilyushchenko
  */
 public class DecoratorController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/ErrorHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/ErrorHandlerController.java
@@ -19,8 +19,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The ErrorHandlerController will show two different views depending on whether the failed request
  * was AJAX or not.
- *
- * @author Vlad Ilyushchenko.
  */
 public class ErrorHandlerController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/RememberVisibilityController.java
+++ b/core/src/main/java/psiprobe/controllers/RememberVisibilityController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class RememberVisibilityController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class RememberVisibilityController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/RenderChartController.java
+++ b/core/src/main/java/psiprobe/controllers/RenderChartController.java
@@ -51,8 +51,6 @@ import javax.servlet.http.HttpServletResponse;
  * <li>l - show legend (boolean: true|false)</li>
  * <li>p - name of series provider bean</li>
  * </ul>
- * 
- * @author Vlad Ilyushchenko
  */
 public class RenderChartController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
+++ b/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
@@ -30,9 +30,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * "Quick check" controller.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class TomcatAvailabilityController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/TomcatContainerController.java
+++ b/core/src/main/java/psiprobe/controllers/TomcatContainerController.java
@@ -18,8 +18,6 @@ import psiprobe.beans.ContainerWrapperBean;
 
 /**
  * Base class for controllers requiring access to ContainerWrapperBean.
- *
- * @author Vlad Ilyushchenko
  */
 public abstract class TomcatContainerController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/WhoisController.java
+++ b/core/src/main/java/psiprobe/controllers/WhoisController.java
@@ -32,8 +32,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class WhoisController.
- *
- * @author Vlad Ilyushchenko
  */
 public class WhoisController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Reloads application context.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class AjaxReloadContextController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Stops a web application.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class AjaxToggleContextController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/AllAppStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AllAppStatsController.java
@@ -18,8 +18,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class AllAppStatsController.
- *
- * @author Mark Lewis
  */
 public class AllAppStatsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
@@ -26,9 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Downloads a deployment descriptor (web.xml) or a context descriptor (context.xml) of a web
- * application
- * 
- * @author Andy Shapoval
+ * application.
  */
 public class DownloadXmlConfController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/GetApplicationController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/GetApplicationController.java
@@ -26,10 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves Application model object populated with application information.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class GetApplicationController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ListAppAttributesController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListAppAttributesController.java
@@ -25,8 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves a list of servlet context attributes for a web application.
- * 
- * @author Andy Shapoval
  */
 public class ListAppAttributesController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ListAppInitParamsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListAppInitParamsController.java
@@ -22,8 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves a list of context initialization parameters for a web application.
- * 
- * @author Andy Shapoval
  */
 public class ListAppInitParamsController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ListApplicationResourcesController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListApplicationResourcesController.java
@@ -20,8 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates a list of resources for a particular web application.
- *
- * @author Vlad Ilyushchenko
  */
 public class ListApplicationResourcesController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ListWebappsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListWebappsController.java
@@ -27,10 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates the list of web application installed in the same "host" as the Probe.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class ListWebappsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/NoSelfContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/NoSelfContextHandlerController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Base class preventing "destructive" actions to be executed on the Probe's context.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
  */
 public abstract class NoSelfContextHandlerController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
@@ -18,8 +18,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Reloads application context.
- * 
- * @author Vlad Ilyushchenko
  */
 public class ReloadContextController extends NoSelfContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/RemoveApplicationAttributeController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/RemoveApplicationAttributeController.java
@@ -22,8 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class RemoveApplicationAttributeController.
- *
- * @author Vlad Ilyushchenko
  */
 public class RemoveApplicationAttributeController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ResetAppStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ResetAppStatsController.java
@@ -14,8 +14,6 @@ import psiprobe.beans.stats.collectors.AppStatsCollectorBean;
 
 /**
  * The Class ResetAppStatsController.
- *
- * @author Mark Lewis
  */
 public class ResetAppStatsController extends NoSelfContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
@@ -17,8 +17,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Starts a web application.
- *
- * @author Vlad Ilyushchenko
  */
 public class StartContextController extends NoSelfContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
@@ -17,8 +17,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Stops a web application.
- *
- * @author Vlad Ilyushchenko
  */
 public class StopContextController extends NoSelfContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
@@ -28,9 +28,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Displays a deployment descriptor (web.xml) or a context descriptor (context.xml) of a web
  * application
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
  */
 public class ViewXmlConfController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/cluster/ClusterStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/cluster/ClusterStatsController.java
@@ -22,9 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ClusterStatsController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ClusterStatsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/connectors/GetConnectorController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/GetConnectorController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class GetConnectorController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class GetConnectorController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/connectors/ListConnectorsController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/ListConnectorsController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ListConnectorsController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListConnectorsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/connectors/ResetConnectorStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/ResetConnectorStatsController.java
@@ -22,8 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ResetConnectorStatsController.
- *
- * @author Mark Lewis
  */
 public class ResetConnectorStatsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/connectors/ZoomChartController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/ZoomChartController.java
@@ -18,8 +18,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ZoomChartController.
- *
- * @author Mark Lewis
  */
 public class ZoomChartController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourceGroups.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourceGroups.java
@@ -27,10 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Produces a list of all datasources configured within the container grouped by JDBC URL.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListAllJdbcResourceGroups extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourcesController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourcesController.java
@@ -22,9 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates a list of all configured datasources for all web applications within the container.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListAllJdbcResourcesController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
@@ -25,9 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Resets datasource if the datasource supports it.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ResetDataSourceController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -40,8 +40,6 @@ import psiprobe.controllers.TomcatContainerController;
 
 /**
  * Lets an user to copy a single file to a deployed context.
- * 
- * @author Sandra Pascual
  */
 public class CopySingleFileController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Forces Tomcat to install a pre-configured context name.
- *
- * @author Vlad Ilyushchenko
  */
 public class DeployContextController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployController.java
@@ -27,8 +27,6 @@ import psiprobe.controllers.TomcatContainerController;
 
 /**
  * Precharges the list of contexts in the deploy page.
- * 
- * @author Sandra Pascual
  */
 public class DeployController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -26,9 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Undeploys a web application.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
  */
 public class UndeployContextController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -40,9 +40,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Uploads and installs web application from a .WAR.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class UploadWarController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/filters/ListAppFilterMapsController.java
+++ b/core/src/main/java/psiprobe/controllers/filters/ListAppFilterMapsController.java
@@ -23,10 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves a list of web application filter mappings.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListAppFilterMapsController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/filters/ListAppFiltersController.java
+++ b/core/src/main/java/psiprobe/controllers/filters/ListAppFiltersController.java
@@ -24,8 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves a list of filter mappings or filter definitions of a web application.
- * 
- * @author Andy Shapoval
  */
 public class ListAppFiltersController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/DiscardCompiledJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DiscardCompiledJspController.java
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class DiscardCompiledJspController.
- *
- * @author Vlad Ilyushchenko
  */
 public class DiscardCompiledJspController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/DisplayJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DisplayJspController.java
@@ -24,8 +24,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * The Class DisplayJspController.
- *
- * @author Vlad Ilyushchenko
  */
 public class DisplayJspController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/DownloadServletController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DownloadServletController.java
@@ -24,8 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class DownloadServletController.
- *
- * @author Vlad Ilyushchenko
  */
 public class DownloadServletController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
@@ -30,8 +30,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * The Class RecompileJspController.
- *
- * @author Vlad Ilyushchenko
  */
 public class RecompileJspController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewServletSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewServletSourceController.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ViewServletSourceController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ViewServletSourceController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
@@ -32,8 +32,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ViewSourceController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ViewSourceController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/ChangeLogLevelController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/ChangeLogLevelController.java
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ChangeLogLevelController.
- *
- * @author Mark Lewis
  */
 public class ChangeLogLevelController extends LogHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
@@ -25,9 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class DownloadLogController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DownloadLogController extends LogHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/FollowController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/FollowController.java
@@ -25,9 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class FollowController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class FollowController extends LogHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/ListLogsController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/ListLogsController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ListLogsController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListLogsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/LogHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/LogHandlerController.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class LogHandlerController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class LogHandlerController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/logs/SetupFollowController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/SetupFollowController.java
@@ -22,9 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class SetupFollowController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class SetupFollowController extends LogHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/servlets/ListServletMapsController.java
+++ b/core/src/main/java/psiprobe/controllers/servlets/ListServletMapsController.java
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of servlet mappings for a particular web application or all web applications if
  * an application name is not passed in a query string.
- * 
- * @author Andy Shapoval
  */
 public class ListServletMapsController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/servlets/ListServletsController.java
+++ b/core/src/main/java/psiprobe/controllers/servlets/ListServletsController.java
@@ -27,8 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of servlets for a particular web application or for all applications if an
  * application name is not passed in a query string.
- * 
- * @author Andy Shapoval
  */
 public class ListServletsController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Expires a single session of a particular web application.
- * 
- * @author Andy Shapoval
  */
 public class ExpireSessionController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionsController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionsController.java
@@ -25,10 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Expires a list of sessionIDs. Accepts a list of sid_webapp parameters that are expected to be in
  * a form of "sid;webapp"
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class ExpireSessionsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/sessions/ListSessionAttributesController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ListSessionAttributesController.java
@@ -24,8 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Retrieves the list of attributes for given session.
- * 
- * @author Vlad Ilyushchenko
  */
 public class ListSessionAttributesController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
@@ -36,9 +36,6 @@ import javax.servlet.http.HttpSession;
 /**
  * Creates the list of sessions for a particular web application or all web applications if a webapp
  * request parameter is not set.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
  */
 public class ListSessionsController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sessions/RemoveSessAttributeController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/RemoveSessAttributeController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class RemoveSessAttributeController.
- *
- * @author Vlad Ilyushchenko
  */
 public class RemoveSessAttributeController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/CachedRecordSetController.java
@@ -28,8 +28,6 @@ import javax.servlet.http.HttpSession;
 /**
  * Displays a result set cached in an attribute of HttpSession object to support result set
  * pagination feature without re-executing a query that created the result set.
- * 
- * @author Andy Shapoval
  */
 public class CachedRecordSetController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
@@ -34,10 +34,6 @@ import javax.sql.DataSource;
 /**
  * Verifies if a database connection can be established through a given datasource. Displays basic
  * information about the database.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
- * @author jackdimm
  */
 public class ConnectionTestController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/DataSourceTestController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/DataSourceTestController.java
@@ -22,9 +22,6 @@ import javax.servlet.http.HttpSession;
 /**
  * Displays a view that allows for a database connectivity testing. Supplies default values to input
  * fields of the view.
- * 
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class DataSourceTestController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
@@ -39,10 +39,6 @@ import javax.sql.DataSource;
 /**
  * Executes an SQL query through a given datasource to test database connectivity. Displays results
  * returned by the query.
- * 
- * @author Andy Shapoval
- * @author Mark Lewis
- * @author jackdimm
  */
 public class ExecuteSqlController extends ContextHandlerController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/QueryHistoryController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/QueryHistoryController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Retrieves a history list of executed queries from a session variable.
- * 
- * @author Andy Shapoval
  */
 public class QueryHistoryController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/QueryHistoryItemController.java
@@ -27,8 +27,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Retrieves a single query from a history list.
- * 
- * @author Andy Shapoval
  */
 public class QueryHistoryItemController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
+++ b/core/src/main/java/psiprobe/controllers/system/AdviseGarbageCollectionController.java
@@ -22,8 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Advises Java to run GC asap.
- * 
- * @author Vlad Ilyushchenko
  */
 public class AdviseGarbageCollectionController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/system/MemoryStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/system/MemoryStatsController.java
@@ -20,9 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class MemoryStatsController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class MemoryStatsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/system/SysInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/system/SysInfoController.java
@@ -27,9 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates an instance of SystemInformation POJO.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class SysInfoController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/GetClassLoaderUrlsController.java
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class GetClassLoaderUrlsController.
- *
- * @author Vlad Ilyushchenko
  */
 public class GetClassLoaderUrlsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/ImplSelectorController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ImplSelectorController.java
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ImplSelectorController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ImplSelectorController extends AbstractController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/KillThreadController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/KillThreadController.java
@@ -22,9 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class KillThreadController.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class KillThreadController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/ListSunThreadsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ListSunThreadsController.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ListSunThreadsController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ListSunThreadsController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/ListThreadPoolsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ListThreadPoolsController.java
@@ -23,9 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates the list of http connection thread pools.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ListThreadPoolsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/ListThreadsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ListThreadsController.java
@@ -27,8 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ListThreadsController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ListThreadsController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/threads/ThreadStackController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ThreadStackController.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ThreadStackController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ThreadStackController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/truststore/TrustStoreController.java
+++ b/core/src/main/java/psiprobe/controllers/truststore/TrustStoreController.java
@@ -32,9 +32,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Creates an instance of SystemInformation POJO.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class TrustStoreController extends TomcatContainerController {
 

--- a/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/RestartJvmController.java
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class RestartJvmController.
- *
- * @author Vlad Ilyushchenko
  */
 public class RestartJvmController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/StopJvmController.java
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class StopJvmController.
- *
- * @author Vlad Ilyushchenko
  */
 public class StopJvmController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/ThreadDumpController.java
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class ThreadDumpController.
- *
- * @author Vlad Ilyushchenko
  */
 public class ThreadDumpController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/wrapper/WrapperInfoController.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class WrapperInfoController.
- *
- * @author Vlad Ilyushchenko
  */
 public class WrapperInfoController extends ParameterizableViewController {
 

--- a/core/src/main/java/psiprobe/jsp/AddQueryParamTag.java
+++ b/core/src/main/java/psiprobe/jsp/AddQueryParamTag.java
@@ -22,9 +22,6 @@ import javax.servlet.jsp.tagext.TagSupport;
 
 /**
  * The Class AddQueryParamTag.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class AddQueryParamTag extends TagSupport {
 

--- a/core/src/main/java/psiprobe/jsp/DurationTag.java
+++ b/core/src/main/java/psiprobe/jsp/DurationTag.java
@@ -20,9 +20,6 @@ import javax.servlet.jsp.tagext.TagSupport;
 
 /**
  * Silly JSP tag to display duration in milliseconds as hours:minutes:seconds.milliseconds
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DurationTag extends TagSupport {
 

--- a/core/src/main/java/psiprobe/jsp/Functions.java
+++ b/core/src/main/java/psiprobe/jsp/Functions.java
@@ -12,8 +12,6 @@ package psiprobe.jsp;
 
 /**
  * The Class Functions.
- *
- * @author Mark Lewis
  */
 public class Functions {
 

--- a/core/src/main/java/psiprobe/jsp/OutTag.java
+++ b/core/src/main/java/psiprobe/jsp/OutTag.java
@@ -20,9 +20,6 @@ import javax.servlet.jsp.tagext.BodyTagSupport;
 
 /**
  * The Class OutTag.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class OutTag extends BodyTagSupport {
 

--- a/core/src/main/java/psiprobe/jsp/ParamToggleTag.java
+++ b/core/src/main/java/psiprobe/jsp/ParamToggleTag.java
@@ -24,9 +24,6 @@ import javax.servlet.jsp.tagext.TagSupport;
 
 /**
  * The Class ParamToggleTag.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ParamToggleTag extends TagSupport {
 

--- a/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
+++ b/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
@@ -23,9 +23,6 @@ import javax.servlet.jsp.tagext.BodyTagSupport;
 
 /**
  * The Class VisualScoreTag.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class VisualScoreTag extends BodyTagSupport {
 

--- a/core/src/main/java/psiprobe/jsp/VolumeTag.java
+++ b/core/src/main/java/psiprobe/jsp/VolumeTag.java
@@ -23,9 +23,6 @@ import javax.servlet.jsp.tagext.TagSupport;
 /**
  * JSP tag to convert size from bytes into human readable form: KB, MB, GB or TB depending on how
  * large the value in bytes is.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class VolumeTag extends TagSupport {
 

--- a/core/src/main/java/psiprobe/mappers/AjaxDecoratorMapper.java
+++ b/core/src/main/java/psiprobe/mappers/AjaxDecoratorMapper.java
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * The AjaxDecoratorMapper will exclude all "ajax" requests from being decorated. It will also make
  * sure that error pages rendered during ajax request execution are not decorated.
- *
- * @author Vlad Ilyushchenko
  */
 public class AjaxDecoratorMapper extends AbstractDecoratorMapper {
 

--- a/core/src/main/java/psiprobe/model/Application.java
+++ b/core/src/main/java/psiprobe/model/Application.java
@@ -14,10 +14,6 @@ import java.io.Serializable;
 
 /**
  * POJO representing Tomcat's web application.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class Application implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/ApplicationParam.java
+++ b/core/src/main/java/psiprobe/model/ApplicationParam.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * A model class representing an application initialization parameter.
- *
- * @author Andy Shapoval
  */
 public class ApplicationParam {
 

--- a/core/src/main/java/psiprobe/model/ApplicationResource.java
+++ b/core/src/main/java/psiprobe/model/ApplicationResource.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * POJO representing application "resource" in Tomcat.
- *
- * @author Vlad Ilyushchenko
  */
 public class ApplicationResource {
 

--- a/core/src/main/java/psiprobe/model/ApplicationSession.java
+++ b/core/src/main/java/psiprobe/model/ApplicationSession.java
@@ -17,9 +17,6 @@ import java.util.Locale;
 
 /**
  * POJO representing HTTP session.
- * 
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
  */
 public class ApplicationSession {
 

--- a/core/src/main/java/psiprobe/model/Attribute.java
+++ b/core/src/main/java/psiprobe/model/Attribute.java
@@ -13,8 +13,6 @@ package psiprobe.model;
 /**
  * This bean represents HttpSession attribute. It is a part of the display model for
  * ListSessionAttributesController.
- *
- * @author Vlad Ilyushchenko
  */
 public class Attribute {
 

--- a/core/src/main/java/psiprobe/model/Connector.java
+++ b/core/src/main/java/psiprobe/model/Connector.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 /**
  * POJO representing a Connector and its RequestProcessors.
- *
- * @author Mark Lewis
  */
 public class Connector {
 

--- a/core/src/main/java/psiprobe/model/DataSourceInfo.java
+++ b/core/src/main/java/psiprobe/model/DataSourceInfo.java
@@ -14,9 +14,6 @@ import psiprobe.Utils;
 
 /**
  * POJO representing a datasource.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DataSourceInfo {
 

--- a/core/src/main/java/psiprobe/model/DataSourceInfoGroup.java
+++ b/core/src/main/java/psiprobe/model/DataSourceInfoGroup.java
@@ -13,8 +13,6 @@ package psiprobe.model;
 /**
  * This POJO represents a group of datasources. It provides methods for adding values to aggregated
  * totals of the group. The class is a part of the ListAllJdbcResourceGroups controller model.
- * 
- * @author Andy Shapoval
  */
 public class DataSourceInfoGroup extends DataSourceInfo {
 

--- a/core/src/main/java/psiprobe/model/DisconnectedLogDestination.java
+++ b/core/src/main/java/psiprobe/model/DisconnectedLogDestination.java
@@ -20,9 +20,6 @@ import java.sql.Timestamp;
  * This class holds attributes of any other LogDestination so that LogDestination can be serialized.
  * It is generally difficult to make just any LogDestination to be serializable as they more often
  * than not are connected to underlying Log implementation that are in many cases not serializable.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DisconnectedLogDestination implements LogDestination, Serializable {
 

--- a/core/src/main/java/psiprobe/model/FilterInfo.java
+++ b/core/src/main/java/psiprobe/model/FilterInfo.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * A model class representing a filter.
- *
- * @author Andy Shapoval
  */
 public class FilterInfo {
 

--- a/core/src/main/java/psiprobe/model/FilterMapping.java
+++ b/core/src/main/java/psiprobe/model/FilterMapping.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * A model class representing a filter mapping item.
- *
- * @author Andy Shapoval
  */
 public class FilterMapping {
 

--- a/core/src/main/java/psiprobe/model/IpInfo.java
+++ b/core/src/main/java/psiprobe/model/IpInfo.java
@@ -14,8 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * The Class IpInfo.
- *
- * @author Mark Lewis
  */
 public class IpInfo {
 

--- a/core/src/main/java/psiprobe/model/RequestProcessor.java
+++ b/core/src/main/java/psiprobe/model/RequestProcessor.java
@@ -14,8 +14,6 @@ import java.util.Locale;
 
 /**
  * POJO representing a single http request processor thread.
- *
- * @author Vlad Ilyushchenko
  */
 public class RequestProcessor {
 

--- a/core/src/main/java/psiprobe/model/ServletInfo.java
+++ b/core/src/main/java/psiprobe/model/ServletInfo.java
@@ -15,9 +15,6 @@ import java.util.List;
 
 /**
  * A model class representing a servlet.
- * 
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class ServletInfo {
 

--- a/core/src/main/java/psiprobe/model/ServletMapping.java
+++ b/core/src/main/java/psiprobe/model/ServletMapping.java
@@ -12,9 +12,6 @@ package psiprobe.model;
 
 /**
  * A model class representing a servlet mapping item.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
  */
 public class ServletMapping {
 

--- a/core/src/main/java/psiprobe/model/SessionSearchInfo.java
+++ b/core/src/main/java/psiprobe/model/SessionSearchInfo.java
@@ -21,9 +21,6 @@ import java.util.regex.PatternSyntaxException;
 
 /**
  * Data model class used by session search feature of application session screen.
- * 
- * @author Andy Shapoval
- * @author Vlad Ilyushchenko
  */
 public class SessionSearchInfo implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/SunThread.java
+++ b/core/src/main/java/psiprobe/model/SunThread.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * The Class SunThread.
- *
- * @author Vlad Ilyushchenko
  */
 public class SunThread {
 

--- a/core/src/main/java/psiprobe/model/SystemInformation.java
+++ b/core/src/main/java/psiprobe/model/SystemInformation.java
@@ -20,8 +20,6 @@ import java.util.Set;
 
 /**
  * POJO representing system information for "system infromation" tab.
- *
- * @author Vlad Ilyushchenko
  */
 public class SystemInformation implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/ThreadPool.java
+++ b/core/src/main/java/psiprobe/model/ThreadPool.java
@@ -12,9 +12,6 @@ package psiprobe.model;
 
 /**
  * POJO representing thread pool.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class ThreadPool {
 

--- a/core/src/main/java/psiprobe/model/ThreadStackElement.java
+++ b/core/src/main/java/psiprobe/model/ThreadStackElement.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * The Class ThreadStackElement.
- *
- * @author Vlad Ilyushchenko
  */
 public class ThreadStackElement {
 

--- a/core/src/main/java/psiprobe/model/TomcatTestReport.java
+++ b/core/src/main/java/psiprobe/model/TomcatTestReport.java
@@ -12,8 +12,6 @@ package psiprobe.model;
 
 /**
  * POJO representing "quick check" report.
- *
- * @author Vlad Ilyushchenko
  */
 public class TomcatTestReport {
 

--- a/core/src/main/java/psiprobe/model/TransportableModel.java
+++ b/core/src/main/java/psiprobe/model/TransportableModel.java
@@ -15,8 +15,6 @@ import java.util.Map;
 
 /**
  * A wrapper class to assist marshalling of ModelAndView.getModel() map to XML representation.
- * 
- * @author Vlad Ilyushchenko
  */
 public class TransportableModel {
 

--- a/core/src/main/java/psiprobe/model/java/ThreadModel.java
+++ b/core/src/main/java/psiprobe/model/java/ThreadModel.java
@@ -12,8 +12,6 @@ package psiprobe.model.java;
 
 /**
  * The Class ThreadModel.
- *
- * @author Vlad Ilyushchenko
  */
 public class ThreadModel {
 

--- a/core/src/main/java/psiprobe/model/jmx/AsyncClusterSender.java
+++ b/core/src/main/java/psiprobe/model/jmx/AsyncClusterSender.java
@@ -12,8 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class AsyncClusterSender.
- *
- * @author Vlad Ilyushchenko
  */
 public class AsyncClusterSender extends SyncClusterSender {
 

--- a/core/src/main/java/psiprobe/model/jmx/Cluster.java
+++ b/core/src/main/java/psiprobe/model/jmx/Cluster.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 /**
  * The Class Cluster.
- *
- * @author Vlad Ilyushchenko
  */
 public class Cluster {
 

--- a/core/src/main/java/psiprobe/model/jmx/ClusterSender.java
+++ b/core/src/main/java/psiprobe/model/jmx/ClusterSender.java
@@ -12,8 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class ClusterSender.
- *
- * @author Vlad Ilyushchenko
  */
 public class ClusterSender {
 

--- a/core/src/main/java/psiprobe/model/jmx/MemoryPool.java
+++ b/core/src/main/java/psiprobe/model/jmx/MemoryPool.java
@@ -12,9 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class MemoryPool.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class MemoryPool {
 

--- a/core/src/main/java/psiprobe/model/jmx/PooledClusterSender.java
+++ b/core/src/main/java/psiprobe/model/jmx/PooledClusterSender.java
@@ -12,8 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class PooledClusterSender.
- *
- * @author Vlad Ilyushchenko
  */
 public class PooledClusterSender extends ClusterSender {
 

--- a/core/src/main/java/psiprobe/model/jmx/RuntimeInformation.java
+++ b/core/src/main/java/psiprobe/model/jmx/RuntimeInformation.java
@@ -12,9 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class RuntimeInformation.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class RuntimeInformation {
 

--- a/core/src/main/java/psiprobe/model/jmx/SyncClusterSender.java
+++ b/core/src/main/java/psiprobe/model/jmx/SyncClusterSender.java
@@ -12,8 +12,6 @@ package psiprobe.model.jmx;
 
 /**
  * The Class SyncClusterSender.
- *
- * @author Vlad Ilyushchenko
  */
 public class SyncClusterSender extends ClusterSender {
 

--- a/core/src/main/java/psiprobe/model/jmx/ThreadPoolObjectName.java
+++ b/core/src/main/java/psiprobe/model/jmx/ThreadPoolObjectName.java
@@ -18,8 +18,6 @@ import javax.management.ObjectName;
 /**
  * This bean represens a hierarchy of Tomcat's ObjectNames necessary to display real-time connection
  * information on "status" tab.
- *
- * @author Vlad Ilyushchenko
  */
 public class ThreadPoolObjectName {
 

--- a/core/src/main/java/psiprobe/model/jsp/CompilerException.java
+++ b/core/src/main/java/psiprobe/model/jsp/CompilerException.java
@@ -12,8 +12,6 @@ package psiprobe.model.jsp;
 
 /**
  * The Class CompilerException.
- *
- * @author Vlad Ilyushchenko
  */
 public class CompilerException extends Exception {
 

--- a/core/src/main/java/psiprobe/model/jsp/Item.java
+++ b/core/src/main/java/psiprobe/model/jsp/Item.java
@@ -16,8 +16,6 @@ import java.util.Date;
 
 /**
  * The Class Item.
- *
- * @author Vlad Ilyushchenko
  */
 public class Item implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/jsp/Summary.java
+++ b/core/src/main/java/psiprobe/model/jsp/Summary.java
@@ -15,8 +15,6 @@ import java.util.Map;
 
 /**
  * The Class Summary.
- *
- * @author Vlad Ilyushchenko
  */
 public class Summary implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/sql/DataSourceTestInfo.java
+++ b/core/src/main/java/psiprobe/model/sql/DataSourceTestInfo.java
@@ -17,8 +17,6 @@ import java.util.Map;
 
 /**
  * A class to store data source test tool related data in a session attribute.
- * 
- * @author Andy Shapoval
  */
 public class DataSourceTestInfo implements Serializable {
 

--- a/core/src/main/java/psiprobe/model/stats/StatsCollection.java
+++ b/core/src/main/java/psiprobe/model/stats/StatsCollection.java
@@ -37,10 +37,6 @@ import java.util.TreeMap;
 
 /**
  * The Class StatsCollection.
- *
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class StatsCollection implements InitializingBean, DisposableBean, ApplicationContextAware {
 

--- a/core/src/main/java/psiprobe/model/wrapper/WrapperInfo.java
+++ b/core/src/main/java/psiprobe/model/wrapper/WrapperInfo.java
@@ -15,8 +15,6 @@ import java.util.Set;
 
 /**
  * The Class WrapperInfo.
- *
- * @author Vlad Ilyushchenko
  */
 public class WrapperInfo {
 

--- a/core/src/main/java/psiprobe/tokenizer/StringTokenizer.java
+++ b/core/src/main/java/psiprobe/tokenizer/StringTokenizer.java
@@ -18,8 +18,6 @@ import java.io.StringReader;
 
 /**
  * The Class StringTokenizer.
- *
- * @author Vlad Ilyushchenko
  */
 public class StringTokenizer extends Tokenizer {
 

--- a/core/src/main/java/psiprobe/tokenizer/Token.java
+++ b/core/src/main/java/psiprobe/tokenizer/Token.java
@@ -12,8 +12,6 @@ package psiprobe.tokenizer;
 
 /**
  * The Interface Token.
- *
- * @author Vlad Ilyushchenko
  */
 public interface Token {
 

--- a/core/src/main/java/psiprobe/tokenizer/Tokenizer.java
+++ b/core/src/main/java/psiprobe/tokenizer/Tokenizer.java
@@ -20,8 +20,6 @@ import java.util.List;
 
 /**
  * The Class Tokenizer.
- *
- * @author Vlad Ilyushchenko
  */
 public class Tokenizer {
 

--- a/core/src/main/java/psiprobe/tokenizer/TokenizerSymbol.java
+++ b/core/src/main/java/psiprobe/tokenizer/TokenizerSymbol.java
@@ -12,8 +12,6 @@ package psiprobe.tokenizer;
 
 /**
  * The Class TokenizerSymbol.
- *
- * @author Vlad Ilyushchenko
  */
 public class TokenizerSymbol implements Comparable<Object> {
 

--- a/core/src/main/java/psiprobe/tokenizer/UniqueList.java
+++ b/core/src/main/java/psiprobe/tokenizer/UniqueList.java
@@ -24,8 +24,6 @@ import java.util.Comparator;
  * provide fast element search based again on e1.compareTo(e2) values.
  * </p>
  *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  * @param <T> the generic type
  */
 public class UniqueList<T extends Comparable<? super T>> extends ArrayList<T> {

--- a/core/src/main/java/psiprobe/tools/Accessor.java
+++ b/core/src/main/java/psiprobe/tools/Accessor.java
@@ -14,8 +14,6 @@ import java.lang.reflect.Field;
 
 /**
  * The Interface Accessor.
- *
- * @author Mark Lewis
  */
 public interface Accessor {
 

--- a/core/src/main/java/psiprobe/tools/AccessorFactory.java
+++ b/core/src/main/java/psiprobe/tools/AccessorFactory.java
@@ -15,8 +15,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A factory for creating Accessor objects.
- *
- * @author Mark Lewis
  */
 public class AccessorFactory {
 

--- a/core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -48,10 +48,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * The Class ApplicationUtils.
- *
- * @author Vlad Ilyushchenko
- * @author Andy Shapoval
- * @author Mark Lewis
  */
 public class ApplicationUtils {
 

--- a/core/src/main/java/psiprobe/tools/AsyncSocketFactory.java
+++ b/core/src/main/java/psiprobe/tools/AsyncSocketFactory.java
@@ -18,8 +18,6 @@ import java.net.Socket;
 
 /**
  * A factory for creating AsyncSocket objects.
- *
- * @author Vlad Ilyushchenko
  */
 public class AsyncSocketFactory {
 

--- a/core/src/main/java/psiprobe/tools/BackwardsFileStream.java
+++ b/core/src/main/java/psiprobe/tools/BackwardsFileStream.java
@@ -17,8 +17,6 @@ import java.io.RandomAccessFile;
 
 /**
  * The Class BackwardsFileStream.
- *
- * @author Vlad Ilyushchenko
  */
 public class BackwardsFileStream extends InputStream {
 

--- a/core/src/main/java/psiprobe/tools/BackwardsLineReader.java
+++ b/core/src/main/java/psiprobe/tools/BackwardsLineReader.java
@@ -21,9 +21,6 @@ import java.io.InputStream;
  * <p>
  * This source code was kindly contributed by Kan Ogawa.
  * </p>
- *
- * @author Kan Ogawa - Original source code.
- * @author Vlad Ilyushchenko - optimised "reverse" method and reduced line buffer size
  */
 public class BackwardsLineReader {
 

--- a/core/src/main/java/psiprobe/tools/Instruments.java
+++ b/core/src/main/java/psiprobe/tools/Instruments.java
@@ -21,9 +21,6 @@ import java.util.Set;
 
 /**
  * The Class Instruments.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Instruments {
 

--- a/core/src/main/java/psiprobe/tools/JmxTools.java
+++ b/core/src/main/java/psiprobe/tools/JmxTools.java
@@ -22,8 +22,6 @@ import javax.management.openmbean.CompositeData;
 
 /**
  * The Class JmxTools.
- *
- * @author Vlad Ilyushchenko
  */
 public class JmxTools {
 

--- a/core/src/main/java/psiprobe/tools/LogOutputStream.java
+++ b/core/src/main/java/psiprobe/tools/LogOutputStream.java
@@ -17,8 +17,6 @@ import java.io.PrintStream;
 
 /**
  * An {@code OutputStream} which writes to a commons-logging {@code Log} at a particular level.
- *
- * @author Mark Lewis
  */
 public class LogOutputStream extends OutputStream {
 

--- a/core/src/main/java/psiprobe/tools/MailMessage.java
+++ b/core/src/main/java/psiprobe/tools/MailMessage.java
@@ -19,8 +19,6 @@ import javax.activation.FileDataSource;
 
 /**
  * The Class MailMessage.
- *
- * @author Mark Lewis
  */
 public class MailMessage {
 

--- a/core/src/main/java/psiprobe/tools/Mailer.java
+++ b/core/src/main/java/psiprobe/tools/Mailer.java
@@ -34,8 +34,6 @@ import javax.mail.internet.MimeMultipart;
 
 /**
  * Facade for sending emails with the JavaMail API.
- * 
- * @author Mark Lewis
  */
 public class Mailer {
 

--- a/core/src/main/java/psiprobe/tools/ObjectWrapper.java
+++ b/core/src/main/java/psiprobe/tools/ObjectWrapper.java
@@ -20,9 +20,6 @@ package psiprobe.tools;
  * instances when calculating object sizes and (2) call {@link Object#hashCode() hashCode()} without
  * fear of an exception or infinite loop.
  * </p>
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  *
  * @see Instruments
  */

--- a/core/src/main/java/psiprobe/tools/ReflectiveAccessor.java
+++ b/core/src/main/java/psiprobe/tools/ReflectiveAccessor.java
@@ -21,8 +21,6 @@ import java.security.PrivilegedAction;
 
 /**
  * The Class ReflectiveAccessor.
- *
- * @author Mark Lewis
  */
 public class ReflectiveAccessor implements Accessor {
 

--- a/core/src/main/java/psiprobe/tools/SecurityUtils.java
+++ b/core/src/main/java/psiprobe/tools/SecurityUtils.java
@@ -20,9 +20,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * The Class SecurityUtils.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class SecurityUtils {
 

--- a/core/src/main/java/psiprobe/tools/SimpleAccessor.java
+++ b/core/src/main/java/psiprobe/tools/SimpleAccessor.java
@@ -17,8 +17,6 @@ import java.lang.reflect.Field;
 
 /**
  * The Class SimpleAccessor.
- *
- * @author Mark Lewis
  */
 public class SimpleAccessor implements Accessor {
 

--- a/core/src/main/java/psiprobe/tools/SizeExpression.java
+++ b/core/src/main/java/psiprobe/tools/SizeExpression.java
@@ -16,8 +16,6 @@ import java.util.regex.Pattern;
 
 /**
  * Tool for parsing and formatting SI-prefixed numbers in base-2 and base-10.
- *
- * @author Mark Lewis
  */
 public class SizeExpression {
 

--- a/core/src/main/java/psiprobe/tools/TimeExpression.java
+++ b/core/src/main/java/psiprobe/tools/TimeExpression.java
@@ -12,8 +12,6 @@ package psiprobe.tools;
 
 /**
  * The Class TimeExpression.
- *
- * @author Mark Lewis
  */
 public class TimeExpression {
 

--- a/core/src/main/java/psiprobe/tools/TimeoutException.java
+++ b/core/src/main/java/psiprobe/tools/TimeoutException.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 
 /**
  * The Class TimeoutException.
- *
- * @author Vlad Ilyushchenko
  */
 public class TimeoutException extends IOException {
 

--- a/core/src/main/java/psiprobe/tools/UpdateCommitLock.java
+++ b/core/src/main/java/psiprobe/tools/UpdateCommitLock.java
@@ -18,9 +18,6 @@ package psiprobe.tools;
  * <p>
  * Commits themselves are not synchronized. It is allowed for two commits to run concurrently.
  * </p>
- * 
- * @author Vlad Ilyushchenko
- * @author Christoph Geiss
  */
 public class UpdateCommitLock {
 

--- a/core/src/main/java/psiprobe/tools/Whois.java
+++ b/core/src/main/java/psiprobe/tools/Whois.java
@@ -25,8 +25,6 @@ import java.util.TreeMap;
 
 /**
  * The Class Whois.
- *
- * @author Vlad Ilyushchenko
  */
 public class Whois {
 

--- a/core/src/main/java/psiprobe/tools/logging/AbstractLogDestination.java
+++ b/core/src/main/java/psiprobe/tools/logging/AbstractLogDestination.java
@@ -15,8 +15,6 @@ import java.sql.Timestamp;
 
 /**
  * The Class AbstractLogDestination.
- *
- * @author Mark Lewis
  */
 public abstract class AbstractLogDestination extends DefaultAccessor implements LogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/DefaultAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/DefaultAccessor.java
@@ -22,9 +22,6 @@ import java.lang.reflect.InvocationTargetException;
 
 /**
  * The Class DefaultAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/FileLogAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/FileLogAccessor.java
@@ -14,9 +14,6 @@ import java.io.File;
 
 /**
  * The Class FileLogAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class FileLogAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/LogDestination.java
+++ b/core/src/main/java/psiprobe/tools/logging/LogDestination.java
@@ -17,9 +17,6 @@ import java.sql.Timestamp;
 
 /**
  * The Interface LogDestination.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public interface LogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
@@ -19,9 +19,6 @@ import java.util.Date;
 
 /**
  * The Class CatalinaLoggerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class CatalinaLoggerAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/commons/CommonsLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/CommonsLoggerAccessor.java
@@ -17,9 +17,6 @@ import java.util.List;
 
 /**
  * The Class CommonsLoggerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class CommonsLoggerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/commons/GetAllDestinationsVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/GetAllDestinationsVisitor.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 /**
  * The Class GetAllDestinationsVisitor.
- *
- * @author Mark Lewis
  */
 public class GetAllDestinationsVisitor extends LoggerAccessorVisitor {
 

--- a/core/src/main/java/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
@@ -16,8 +16,6 @@ import psiprobe.tools.logging.log4j.Log4JLoggerAccessor;
 
 /**
  * The Class GetSingleDestinationVisitor.
- *
- * @author Mark Lewis
  */
 public class GetSingleDestinationVisitor extends LoggerAccessorVisitor {
 

--- a/core/src/main/java/psiprobe/tools/logging/commons/LoggerAccessorVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/LoggerAccessorVisitor.java
@@ -17,8 +17,6 @@ import psiprobe.tools.logging.log4j.Log4JLoggerAccessor;
 
 /**
  * The Class LoggerAccessorVisitor.
- *
- * @author Mark Lewis
  */
 public abstract class LoggerAccessorVisitor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14HandlerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14HandlerAccessor.java
@@ -16,9 +16,6 @@ import psiprobe.tools.logging.AbstractLogDestination;
 
 /**
  * The Class Jdk14HandlerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Jdk14HandlerAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
@@ -21,9 +21,6 @@ import java.util.List;
 
 /**
  * The Class Jdk14LoggerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Jdk14LoggerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14ManagerAccessor.java
@@ -24,9 +24,6 @@ import java.util.List;
 
 /**
  * The Class Jdk14ManagerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Jdk14ManagerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/jdk/JuliHandlerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/JuliHandlerAccessor.java
@@ -16,9 +16,6 @@ import java.io.File;
 
 /**
  * The Class JuliHandlerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class JuliHandlerAccessor extends Jdk14HandlerAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/log4j/Log4JAppenderAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j/Log4JAppenderAccessor.java
@@ -16,9 +16,6 @@ import java.io.File;
 
 /**
  * The Class Log4JAppenderAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Log4JAppenderAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/log4j/Log4JLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j/Log4JLoggerAccessor.java
@@ -21,9 +21,6 @@ import java.util.List;
 
 /**
  * The Class Log4JLoggerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Log4JLoggerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j/Log4JManagerAccessor.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 /**
  * The Class Log4JManagerAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Log4JManagerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackAppenderAccessor.java
@@ -20,8 +20,6 @@ import java.io.File;
 
 /**
  * A wrapper for a Logback appender for a specific logger.
- * 
- * @author Harald Wellmann
  */
 public class LogbackAppenderAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackFactoryAccessor.java
@@ -29,8 +29,6 @@ import java.util.List;
  * <p>
  * This way, we can even handle different versions of Logback embedded in different WARs.
  * </p>
- * 
- * @author Harald Wellmann
  */
 public class LogbackFactoryAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 /**
  * A wrapper for a Logback logger.
- * 
- * @author Harald Wellmann
- * @author Mark Lewis
  */
 public class LogbackLoggerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackAppenderAccessor.java
@@ -16,8 +16,6 @@ import java.io.File;
 
 /**
  * A wrapper for a TomcatSlf4jLogback appender for a specific logger.
- * 
- * @author Jeremy Landis
  */
 public class TomcatSlf4jLogbackAppenderAccessor extends AbstractLogDestination {
 

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackFactoryAccessor.java
@@ -30,8 +30,6 @@ import java.util.List;
  * <p>
  * This way, we can even handle different versions of TomcatSlf4jLogback embedded in different WARs.
  * </p>
- * 
- * @author Jeremy Landis
  */
 public class TomcatSlf4jLogbackFactoryAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 /**
  * A wrapper for a TomcatSlf4jLogback logger.
- * 
- * @author Jeremy Landis
  */
 public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
 

--- a/core/src/main/java/psiprobe/tools/url/UrlParser.java
+++ b/core/src/main/java/psiprobe/tools/url/UrlParser.java
@@ -17,8 +17,6 @@ import java.net.MalformedURLException;
 
 /**
  * The Class UrlParser.
- *
- * @author Vlad Ilyushchenko
  */
 public class UrlParser {
 

--- a/core/src/test/java/psiprobe/beans/stats/listeners/FlapListenerTests.java
+++ b/core/src/test/java/psiprobe/beans/stats/listeners/FlapListenerTests.java
@@ -18,8 +18,6 @@ import psiprobe.beans.stats.listeners.StatsCollectionEvent;
 
 /**
  * The Class FlapListenerTests.
- *
- * @author Mark Lewis
  */
 public class FlapListenerTests {
 

--- a/core/src/test/java/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
+++ b/core/src/test/java/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
@@ -18,8 +18,6 @@ import psiprobe.beans.stats.listeners.ThresholdListener;
 
 /**
  * The Class ThresholdListenerTests.
- *
- * @author Mark Lewis
  */
 public class ThresholdListenerTests {
 

--- a/core/src/test/java/psiprobe/tools/InstrumentsTests.java
+++ b/core/src/test/java/psiprobe/tools/InstrumentsTests.java
@@ -19,8 +19,6 @@ import psiprobe.tools.Instruments;
 
 /**
  * The Class InstrumentsTests.
- *
- * @author Mark Lewis
  */
 public class InstrumentsTests {
 

--- a/core/src/test/java/psiprobe/tools/SizeExpressionTests.java
+++ b/core/src/test/java/psiprobe/tools/SizeExpressionTests.java
@@ -21,8 +21,6 @@ import java.util.Locale;
 
 /**
  * The Class SizeExpressionTests.
- *
- * @author Mark Lewis
  */
 public class SizeExpressionTests {
 

--- a/core/src/test/java/psiprobe/tools/WhoisTests.java
+++ b/core/src/test/java/psiprobe/tools/WhoisTests.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 
 /**
  * The Class WhoisTests.
- *
- * @author Mark Lewis
  */
 public class WhoisTests {
 

--- a/tomcat70adapter/src/main/java/psiprobe/Tomcat70AgentValve.java
+++ b/tomcat70adapter/src/main/java/psiprobe/Tomcat70AgentValve.java
@@ -25,9 +25,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Valve which inserts the client's IP address into the session for Tomcat 7.0.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Tomcat70AgentValve extends ValveBase {
 

--- a/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
+++ b/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
@@ -42,9 +42,6 @@ import javax.servlet.ServletContext;
 
 /**
  * The Class Tomcat70ContainerAdapter.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
 

--- a/tomcat70adapter/src/main/java/psiprobe/beans/Tomcat7DbcpDatasourceAccessor.java
+++ b/tomcat70adapter/src/main/java/psiprobe/beans/Tomcat7DbcpDatasourceAccessor.java
@@ -16,9 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * DBCP datasource abstraction layer.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
  */
 public class Tomcat7DbcpDatasourceAccessor implements DatasourceAccessor {
 

--- a/tomcat80adapter/src/main/java/psiprobe/Tomcat80AgentValve.java
+++ b/tomcat80adapter/src/main/java/psiprobe/Tomcat80AgentValve.java
@@ -25,10 +25,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Valve which inserts the client's IP address into the session for Tomcat 8.0.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat80AgentValve extends ValveBase {
 

--- a/tomcat80adapter/src/main/java/psiprobe/Tomcat80ContainerAdapter.java
+++ b/tomcat80adapter/src/main/java/psiprobe/Tomcat80ContainerAdapter.java
@@ -42,10 +42,6 @@ import javax.servlet.ServletContext;
 
 /**
  * The Class Tomcat80ContainerAdapter.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat80ContainerAdapter extends AbstractTomcatContainer {
 

--- a/tomcat80adapter/src/main/java/psiprobe/beans/Tomcat8DbcpDatasourceAccessor.java
+++ b/tomcat80adapter/src/main/java/psiprobe/beans/Tomcat8DbcpDatasourceAccessor.java
@@ -16,10 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * The Class Tomcat8DbcpDatasourceAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author <a href="mailto:diogosantana@gmail.com">Diogo Sant'Ana</a>
  */
 public class Tomcat8DbcpDatasourceAccessor implements DatasourceAccessor {
 

--- a/tomcat85adapter/src/main/java/psiprobe/Tomcat85AgentValve.java
+++ b/tomcat85adapter/src/main/java/psiprobe/Tomcat85AgentValve.java
@@ -25,10 +25,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Valve which inserts the client's IP address into the session for Tomcat 8.5.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat85AgentValve extends ValveBase {
 

--- a/tomcat85adapter/src/main/java/psiprobe/Tomcat85ContainerAdapter.java
+++ b/tomcat85adapter/src/main/java/psiprobe/Tomcat85ContainerAdapter.java
@@ -42,10 +42,6 @@ import javax.servlet.ServletContext;
 
 /**
  * The Class Tomcat85ContainerAdapter.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat85ContainerAdapter extends AbstractTomcatContainer {
 

--- a/tomcat85adapter/src/main/java/psiprobe/beans/Tomcat85DbcpDatasourceAccessor.java
+++ b/tomcat85adapter/src/main/java/psiprobe/beans/Tomcat85DbcpDatasourceAccessor.java
@@ -16,10 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * The Class Tomcat8DbcpDatasourceAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author <a href="mailto:diogosantana@gmail.com">Diogo Sant'Ana</a>
  */
 public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
 

--- a/tomcat90adapter/src/main/java/psiprobe/Tomcat90AgentValve.java
+++ b/tomcat90adapter/src/main/java/psiprobe/Tomcat90AgentValve.java
@@ -25,10 +25,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Valve which inserts the client's IP address into the session for Tomcat 8.0.
- * 
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat90AgentValve extends ValveBase {
 

--- a/tomcat90adapter/src/main/java/psiprobe/Tomcat90ContainerAdapter.java
+++ b/tomcat90adapter/src/main/java/psiprobe/Tomcat90ContainerAdapter.java
@@ -41,10 +41,6 @@ import javax.servlet.ServletContext;
 
 /**
  * The Class Tomcat80ContainerAdapter.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author Andre Sollie
  */
 public class Tomcat90ContainerAdapter extends AbstractTomcatContainer {
 

--- a/tomcat90adapter/src/main/java/psiprobe/beans/Tomcat9DbcpDatasourceAccessor.java
+++ b/tomcat90adapter/src/main/java/psiprobe/beans/Tomcat9DbcpDatasourceAccessor.java
@@ -16,10 +16,6 @@ import psiprobe.model.DataSourceInfo;
 
 /**
  * The Class Tomcat8DbcpDatasourceAccessor.
- *
- * @author Vlad Ilyushchenko
- * @author Mark Lewis
- * @author <a href="mailto:diogosantana@gmail.com">Diogo Sant'Ana</a>
  */
 public class Tomcat9DbcpDatasourceAccessor implements DatasourceAccessor {
 


### PR DESCRIPTION
… otherwise noted by license.

Additional reasons.

1) Prevents high duplication problems when new classes created via copy/paste applying owners that had no involvement.
2) Doesn't allow us to blame the code but instead blame the author.
3) Git has blame ability for files.  Again not to blame the author.
4) No point in @author in public code (back to original point)