### PR TITLE
Slf4j/Logback Upgrade plus code fix - Fixes #720

### DIFF
--- a/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/logback/LogbackLoggerAccessor.java
@@ -44,6 +44,9 @@ public class LogbackLoggerAccessor extends DefaultAccessor {
           wrapAndAddAppender(appender, appenders);
         }
       }
+    } catch (NoClassDefFoundError e) {
+      logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
+      logger.error("To see this logger, upgrade slf4j to 1.7.21+");
     } catch (Exception e) {
       logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
     }

--- a/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/slf4jlogback/TomcatSlf4jLogbackLoggerAccessor.java
@@ -16,7 +16,6 @@ import org.apache.commons.collections.IteratorUtils;
 import psiprobe.tools.logging.DefaultAccessor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -46,6 +45,9 @@ public class TomcatSlf4jLogbackLoggerAccessor extends DefaultAccessor {
           wrapAndAddAppender(appender, appenders);
         }
       }
+    } catch (NoClassDefFoundError e) {
+        logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
+        logger.error("To see this logger, upgrade slf4j to 1.7.21+");
     } catch (Exception e) {
       logger.error("{}#getAppenders() failed", getTarget().getClass().getName(), e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.7</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -274,12 +274,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
-                <version>1.7.13</version>
+                <version>1.7.21</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.13</version>
+                <version>1.7.21</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
Fixes #720 

Issue was not so much with us using newer logback as that worked fine but rather if user misconfigures logback to be at a version higher than slf4j within their war.  That would cause this issue reported originally in #719.  After much testing, it did not matter if psi probe and tomcat-juli versions were newer.  It seemed to simply be setting slf4j-api to older than 1.7.14 and logback newer than 1.1.5 (there abouts).  Anyway, this fix will simply allow logs to still display that can be understood and a log will be written with the stack trace plus a note to upgrade slf4j to 1.7.21 or better.  Effectively this is better and no worse than all the X number of logs we already don't show.  I don't see any other real way to address this and at this point, I'd rather push people forwards as latest slf4j/logback has been out for quite some time so it's not that huge of a push.