### PR TITLE
[logs] Rename '/logs/index.htm' to '/logs/list.htm'

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/decorators/probe.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/decorators/probe.jsp
@@ -71,7 +71,7 @@
 					</a>
 				</li>
 				<li>
-					<a class="${navTabLogs}" href="<c:url value='/logs/index.htm'/>">
+					<a class="${navTabLogs}" href="<c:url value='/logs/list.htm'/>">
 						<spring:message code="probe.jsp.menu.logs"/>
 					</a>
 				</li>
@@ -139,7 +139,7 @@
 					</a>
 				</li>
 				<li>
-					<a href="<c:url value='/logs/index.htm'/>">
+					<a href="<c:url value='/logs/list.htm'/>">
 						<spring:message code="probe.jsp.menu.logs"/>
 					</a>
 				</li>

--- a/web/src/main/webapp/WEB-INF/jsp/follow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/follow.jsp
@@ -38,7 +38,7 @@
 
 		<ul class="options">
 			<li id="back">
-				<a href="<c:url value='/logs/index.htm'/>">
+				<a href="<c:url value='/logs/list.htm'/>">
 					<spring:message code="probe.jsp.follow.menu.back"/>
 				</a>
 			</li>

--- a/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
@@ -439,7 +439,7 @@
 		<property name="viewName" value="/connectors.htm"/>
 	</bean>
 
-	<bean name="/logs,/logs/index.htm" class="psiprobe.controllers.logs.ListLogsController">
+	<bean name="/logs,/logs/list.htm" class="psiprobe.controllers.logs.ListLogsController">
 		<property name="logResolver" ref="logResolver"/>
 		<property name="viewName" value="logs"/>
 		<property name="errorView" value="logs_notsupported"/>


### PR DESCRIPTION
Preparing for switching to spring annotations.  There is a conflict using 'index.htm' in this way.  After review, 'list' makes the most sense so switching it.