### PR TITLE
[java] Rename abstract classes to contain keyword 'Abstract' so it's clear file is abstract

### DIFF
--- a/core/src/main/java/psiprobe/beans/LogResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/LogResolverBean.java
@@ -103,7 +103,7 @@ public class LogResolverBean {
       // this list has to guarantee the order in which elements are added
       //
       List<LogDestination> uniqueList = new LinkedList<>();
-      LogComparator cmp = new LogDestinationComparator(all);
+      AbstractLogComparator cmp = new LogDestinationComparator(all);
 
       Collections.sort(allAppenders, cmp);
       for (LogDestination dest : allAppenders) {
@@ -145,7 +145,7 @@ public class LogResolverBean {
 
     List<LogDestination> allAppenders = getAllLogDestinations();
     if (allAppenders != null) {
-      LogComparator cmp = new LogSourceComparator();
+      AbstractLogComparator cmp = new LogSourceComparator();
 
       Collections.sort(allAppenders, cmp);
       for (LogDestination dest : allAppenders) {
@@ -548,7 +548,7 @@ public class LogResolverBean {
   /**
    * The Class LogComparator.
    */
-  private abstract static class LogComparator implements Comparator<LogDestination> {
+  private abstract static class AbstractLogComparator implements Comparator<LogDestination> {
 
     /** The Constant DELIM. */
     protected static final char DELIM = '!';
@@ -573,7 +573,7 @@ public class LogResolverBean {
   /**
    * The Class LogDestinationComparator.
    */
-  private static class LogDestinationComparator extends LogComparator {
+  private static class LogDestinationComparator extends AbstractLogComparator {
 
     /** The all. */
     private final boolean all;
@@ -610,7 +610,7 @@ public class LogResolverBean {
   /**
    * The Class LogSourceComparator.
    */
-  private static class LogSourceComparator extends LogComparator {
+  private static class LogSourceComparator extends AbstractLogComparator {
 
     @Override
     protected String convertToString(LogDestination dest) {

--- a/core/src/main/java/psiprobe/beans/stats/listeners/AbstractFlapListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/AbstractFlapListener.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
  * @see <a href="http://nagios.sourceforge.net/docs/3_0/flapping.html">Detection and Handling of
  *      State Flapping (nagios)</a>
  */
-public abstract class FlapListener extends ThresholdListener {
+public abstract class AbstractFlapListener extends AbstractThresholdListener {
 
   /** The default flap interval. */
   private int defaultFlapInterval;

--- a/core/src/main/java/psiprobe/beans/stats/listeners/AbstractThresholdListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/AbstractThresholdListener.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
  * with a component using the component's {@code addThresholdListener} method. When the threshold
  * event occurs, that object's appropriate method is invoked.
  */
-public abstract class ThresholdListener extends AbstractStatsCollectionListener {
+public abstract class AbstractThresholdListener extends AbstractStatsCollectionListener {
 
   /** The Constant DEFAULT_THRESHOLD. */
   public static final long DEFAULT_THRESHOLD = Long.MAX_VALUE;

--- a/core/src/main/java/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
+++ b/core/src/main/java/psiprobe/beans/stats/listeners/MemoryPoolMailingListener.java
@@ -26,7 +26,7 @@ import javax.mail.MessagingException;
  * class is registered with a component using the component's {@code addMemoryPoolMailingListener}
  * method. When the memoryPoolMailing event occurs, that object's appropriate method is invoked.
  */
-public class MemoryPoolMailingListener extends FlapListener implements MessageSourceAware,
+public class MemoryPoolMailingListener extends AbstractFlapListener implements MessageSourceAware,
     InitializingBean {
 
   /** The Constant BASE_PROPERTY. */

--- a/core/src/main/java/psiprobe/controllers/AbstractContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/AbstractContextHandlerController.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Base class for all controllers requiring "webapp" request parameter.
  */
-public abstract class ContextHandlerController extends TomcatContainerController {
+public abstract class AbstractContextHandlerController extends AbstractTomcatContainerController {
 
   /** The logger. */
   protected Logger logger = LoggerFactory.getLogger(getClass());

--- a/core/src/main/java/psiprobe/controllers/AbstractTomcatContainerController.java
+++ b/core/src/main/java/psiprobe/controllers/AbstractTomcatContainerController.java
@@ -19,7 +19,7 @@ import psiprobe.beans.ContainerWrapperBean;
 /**
  * Base class for controllers requiring access to ContainerWrapperBean.
  */
-public abstract class TomcatContainerController extends AbstractController {
+public abstract class AbstractTomcatContainerController extends AbstractController {
 
   /** The logger. */
   protected Logger logger = LoggerFactory.getLogger(getClass());

--- a/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
+++ b/core/src/main/java/psiprobe/controllers/TomcatAvailabilityController.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * "Quick check" controller.
  */
-public class TomcatAvailabilityController extends TomcatContainerController {
+public class TomcatAvailabilityController extends AbstractTomcatContainerController {
 
   /** The container listener bean. */
   private ContainerListenerBean containerListenerBean;

--- a/core/src/main/java/psiprobe/controllers/apps/AbstractNoSelfContextHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AbstractNoSelfContextHandlerController.java
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,10 +25,10 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Base class preventing "destructive" actions to be executed on the Probe's context.
  */
-public abstract class NoSelfContextHandlerController extends ContextHandlerController {
+public abstract class AbstractNoSelfContextHandlerController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(NoSelfContextHandlerController.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractNoSelfContextHandlerController.class);
 
   /** The pass query string. */
   private boolean passQueryString;

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxReloadContextController.java
@@ -17,7 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Reloads application context.
  */
-public class AjaxReloadContextController extends ContextHandlerController {
+public class AjaxReloadContextController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/AjaxToggleContextController.java
@@ -17,7 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Stops a web application.
  */
-public class AjaxToggleContextController extends ContextHandlerController {
+public class AjaxToggleContextController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(AjaxReloadContextController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/DownloadXmlConfController.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.Utils;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
  * Downloads a deployment descriptor (web.xml) or a context descriptor (context.xml) of a web
  * application.
  */
-public class DownloadXmlConfController extends ContextHandlerController {
+public class DownloadXmlConfController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(DownloadXmlConfController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/GetApplicationController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/GetApplicationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.beans.ResourceResolver;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.Application;
 import psiprobe.model.stats.StatsCollection;
 import psiprobe.tools.ApplicationUtils;
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves Application model object populated with application information.
  */
-public class GetApplicationController extends ContextHandlerController {
+public class GetApplicationController extends AbstractContextHandlerController {
 
   /** denotes whether extended application information and statistics should be collected. */
   private boolean extendedInfo = false;

--- a/core/src/main/java/psiprobe/controllers/apps/ListAppAttributesController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListAppAttributesController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.apps;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.Attribute;
 import psiprobe.tools.ApplicationUtils;
 import psiprobe.tools.SecurityUtils;
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of servlet context attributes for a web application.
  */
-public class ListAppAttributesController extends ContextHandlerController {
+public class ListAppAttributesController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/apps/ListAppInitParamsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListAppInitParamsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.apps;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.tools.ApplicationUtils;
 import psiprobe.tools.SecurityUtils;
 
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of context initialization parameters for a web application.
  */
-public class ListAppInitParamsController extends ContextHandlerController {
+public class ListAppInitParamsController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/apps/ListApplicationResourcesController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListApplicationResourcesController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.apps;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates a list of resources for a particular web application.
  */
-public class ListApplicationResourcesController extends ContextHandlerController {
+public class ListApplicationResourcesController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/apps/ListWebappsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ListWebappsController.java
@@ -14,7 +14,7 @@ import org.apache.catalina.Context;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.Application;
 import psiprobe.tools.ApplicationUtils;
 import psiprobe.tools.SecurityUtils;
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates the list of web application installed in the same "host" as the Probe.
  */
-public class ListWebappsController extends TomcatContainerController {
+public class ListWebappsController extends AbstractTomcatContainerController {
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ReloadContextController.java
@@ -19,7 +19,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /**
  * Reloads application context.
  */
-public class ReloadContextController extends NoSelfContextHandlerController {
+public class ReloadContextController extends AbstractNoSelfContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/RemoveApplicationAttributeController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/RemoveApplicationAttributeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class RemoveApplicationAttributeController.
  */
-public class RemoveApplicationAttributeController extends ContextHandlerController {
+public class RemoveApplicationAttributeController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/apps/ResetAppStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ResetAppStatsController.java
@@ -15,7 +15,7 @@ import psiprobe.beans.stats.collectors.AppStatsCollectorBean;
 /**
  * The Class ResetAppStatsController.
  */
-public class ResetAppStatsController extends NoSelfContextHandlerController {
+public class ResetAppStatsController extends AbstractNoSelfContextHandlerController {
 
   /** The stats collector. */
   private AppStatsCollectorBean statsCollector;

--- a/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StartContextController.java
@@ -18,7 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /**
  * Starts a web application.
  */
-public class StartContextController extends NoSelfContextHandlerController {
+public class StartContextController extends AbstractNoSelfContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(StartContextController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/StopContextController.java
@@ -18,7 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /**
  * Stops a web application.
  */
-public class StopContextController extends NoSelfContextHandlerController {
+public class StopContextController extends AbstractNoSelfContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(StopContextController.class);

--- a/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
+++ b/core/src/main/java/psiprobe/controllers/apps/ViewXmlConfController.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.Utils;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletResponse;
  * Displays a deployment descriptor (web.xml) or a context descriptor (context.xml) of a web
  * application
  */
-public class ViewXmlConfController extends ContextHandlerController {
+public class ViewXmlConfController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(ViewXmlConfController.class);

--- a/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
+++ b/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.certificates.Cert;
 import psiprobe.model.certificates.ConnectorInfo;
 
@@ -43,7 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ListCertificatesController.
  */
-public class ListCertificatesController extends TomcatContainerController {
+public class ListCertificatesController extends AbstractTomcatContainerController {
 
   /** The Constant Logger. */
   private static final Logger logger = LoggerFactory.getLogger(ListCertificatesController.class);

--- a/core/src/main/java/psiprobe/controllers/cluster/ClusterStatsController.java
+++ b/core/src/main/java/psiprobe/controllers/cluster/ClusterStatsController.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.TomcatContainer;
 import psiprobe.beans.ClusterWrapperBean;
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.jmx.Cluster;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ClusterStatsController.
  */
-public class ClusterStatsController extends TomcatContainerController {
+public class ClusterStatsController extends AbstractTomcatContainerController {
 
   /** The cluster wrapper. */
   private ClusterWrapperBean clusterWrapper;

--- a/core/src/main/java/psiprobe/controllers/connectors/GetConnectorController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/GetConnectorController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.beans.ContainerListenerBean;
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.Connector;
 
 import java.util.List;
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class GetConnectorController.
  */
-public class GetConnectorController extends TomcatContainerController {
+public class GetConnectorController extends AbstractTomcatContainerController {
 
   /** The container listener bean. */
   private ContainerListenerBean containerListenerBean;

--- a/core/src/main/java/psiprobe/controllers/connectors/ListConnectorsController.java
+++ b/core/src/main/java/psiprobe/controllers/connectors/ListConnectorsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.connectors;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.beans.ContainerListenerBean;
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.Connector;
 import psiprobe.model.RequestProcessor;
 
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ListConnectorsController.
  */
-public class ListConnectorsController extends TomcatContainerController {
+public class ListConnectorsController extends AbstractTomcatContainerController {
 
   /** The container listener bean. */
   private ContainerListenerBean containerListenerBean;

--- a/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourceGroupsController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourceGroupsController.java
@@ -12,7 +12,7 @@ package psiprobe.controllers.datasources;
 
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.ApplicationResource;
 import psiprobe.model.DataSourceInfo;
 import psiprobe.model.DataSourceInfoGroup;
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Produces a list of all datasources configured within the container grouped by JDBC URL.
  */
-public class ListAllJdbcResourceGroupsController extends TomcatContainerController {
+public class ListAllJdbcResourceGroupsController extends AbstractTomcatContainerController {
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourcesController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ListAllJdbcResourcesController.java
@@ -12,7 +12,7 @@ package psiprobe.controllers.datasources;
 
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.ApplicationResource;
 
 import java.util.List;
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates a list of all configured datasources for all web applications within the container.
  */
-public class ListAllJdbcResourcesController extends TomcatContainerController {
+public class ListAllJdbcResourcesController extends AbstractTomcatContainerController {
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.naming.NamingException;
 import javax.servlet.http.HttpServletRequest;
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Resets datasource if the datasource supports it.
  */
-public class ResetDataSourceController extends ContextHandlerController {
+public class ResetDataSourceController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(ResetDataSourceController.class);

--- a/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -36,12 +36,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 
 /**
  * Lets an user to copy a single file to a deployed context.
  */
-public class CopySingleFileController extends TomcatContainerController {
+public class CopySingleFileController extends AbstractTomcatContainerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(CopySingleFileController.class);

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployContextController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Forces Tomcat to install a pre-configured context name.
  */
-public class DeployContextController extends TomcatContainerController {
+public class DeployContextController extends AbstractTomcatContainerController {
 
   @Override
   public ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)

--- a/core/src/main/java/psiprobe/controllers/deploy/DeployController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/DeployController.java
@@ -23,12 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 
 /**
  * Precharges the list of contexts in the deploy page.
  */
-public class DeployController extends TomcatContainerController {
+public class DeployController extends AbstractTomcatContainerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(DeployController.class);

--- a/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UndeployContextController.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Undeploys a web application.
  */
-public class UndeployContextController extends ContextHandlerController {
+public class UndeployContextController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(UndeployContextController.class);

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -26,7 +26,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.controllers.jsp.DisplayJspController;
 import psiprobe.model.jsp.Summary;
 
@@ -41,7 +41,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Uploads and installs web application from a .WAR.
  */
-public class UploadWarController extends TomcatContainerController {
+public class UploadWarController extends AbstractTomcatContainerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(UploadWarController.class);

--- a/core/src/main/java/psiprobe/controllers/filters/ListAppFilterMapsController.java
+++ b/core/src/main/java/psiprobe/controllers/filters/ListAppFilterMapsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.filters;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.FilterMapping;
 
 import java.util.List;
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of web application filter mappings.
  */
-public class ListAppFilterMapsController extends ContextHandlerController {
+public class ListAppFilterMapsController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/filters/ListAppFiltersController.java
+++ b/core/src/main/java/psiprobe/controllers/filters/ListAppFiltersController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.filters;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.FilterInfo;
 import psiprobe.tools.ApplicationUtils;
 
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves a list of filter mappings or filter definitions of a web application.
  */
-public class ListAppFiltersController extends ContextHandlerController {
+public class ListAppFiltersController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/jsp/DiscardCompiledJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DiscardCompiledJspController.java
@@ -14,7 +14,7 @@ import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class DiscardCompiledJspController.
  */
-public class DiscardCompiledJspController extends ContextHandlerController {
+public class DiscardCompiledJspController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/jsp/DisplayJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DisplayJspController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.jsp.Summary;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpSession;
 /**
  * The Class DisplayJspController.
  */
-public class DisplayJspController extends ContextHandlerController {
+public class DisplayJspController extends AbstractContextHandlerController {
 
   /** The Constant SUMMARY_ATTRIBUTE. */
   public static final String SUMMARY_ATTRIBUTE = "jsp.summary";

--- a/core/src/main/java/psiprobe/controllers/jsp/DownloadServletController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/DownloadServletController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.Utils;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import java.io.File;
 
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class DownloadServletController.
  */
-public class DownloadServletController extends ContextHandlerController {
+public class DownloadServletController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/RecompileJspController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.jsp.Summary;
 
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpSession;
 /**
  * The Class RecompileJspController.
  */
-public class RecompileJspController extends ContextHandlerController {
+public class RecompileJspController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(RecompileJspController.class);

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewServletSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewServletSourceController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.Utils;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ViewServletSourceController.
  */
-public class ViewServletSourceController extends ContextHandlerController {
+public class ViewServletSourceController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
+++ b/core/src/main/java/psiprobe/controllers/jsp/ViewSourceController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.Utils;
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.jsp.Item;
 import psiprobe.model.jsp.Summary;
 
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ViewSourceController.
  */
-public class ViewSourceController extends ContextHandlerController {
+public class ViewSourceController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(ViewSourceController.class);

--- a/core/src/main/java/psiprobe/controllers/servlets/ListServletMapsController.java
+++ b/core/src/main/java/psiprobe/controllers/servlets/ListServletMapsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.servlets;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.ServletMapping;
 import psiprobe.tools.ApplicationUtils;
 
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
  * Retrieves a list of servlet mappings for a particular web application or all web applications if
  * an application name is not passed in a query string.
  */
-public class ListServletMapsController extends ContextHandlerController {
+public class ListServletMapsController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/servlets/ListServletsController.java
+++ b/core/src/main/java/psiprobe/controllers/servlets/ListServletsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.servlets;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.ServletInfo;
 import psiprobe.tools.ApplicationUtils;
 
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
  * Retrieves a list of servlets for a particular web application or for all applications if an
  * application name is not passed in a query string.
  */
-public class ListServletsController extends ContextHandlerController {
+public class ListServletsController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Expires a single session of a particular web application.
  */
-public class ExpireSessionController extends ContextHandlerController {
+public class ExpireSessionController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionsController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ExpireSessionsController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.InternalResourceView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
  * Expires a list of sessionIDs. Accepts a list of sid_webapp parameters that are expected to be in
  * a form of "sid;webapp"
  */
-public class ExpireSessionsController extends TomcatContainerController {
+public class ExpireSessionsController extends AbstractTomcatContainerController {
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/sessions/ListSessionAttributesController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ListSessionAttributesController.java
@@ -14,7 +14,7 @@ import org.apache.catalina.Context;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.ApplicationSession;
 import psiprobe.tools.ApplicationUtils;
 import psiprobe.tools.SecurityUtils;
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Retrieves the list of attributes for given session.
  */
-public class ListSessionAttributesController extends ContextHandlerController {
+public class ListSessionAttributesController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/ListSessionsController.java
@@ -17,7 +17,7 @@ import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.ApplicationSession;
 import psiprobe.model.Attribute;
 import psiprobe.model.SessionSearchInfo;
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpSession;
  * Creates the list of sessions for a particular web application or all web applications if a webapp
  * request parameter is not set.
  */
-public class ListSessionsController extends ContextHandlerController {
+public class ListSessionsController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/sessions/RemoveSessAttributeController.java
+++ b/core/src/main/java/psiprobe/controllers/sessions/RemoveSessAttributeController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class RemoveSessAttributeController.
  */
-public class RemoveSessAttributeController extends ContextHandlerController {
+public class RemoveSessAttributeController extends AbstractContextHandlerController {
 
   @Override
   protected ModelAndView handleContext(String contextName, Context context,

--- a/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -35,7 +35,7 @@ import javax.sql.DataSource;
  * Verifies if a database connection can be established through a given datasource. Displays basic
  * information about the database.
  */
-public class ConnectionTestController extends ContextHandlerController {
+public class ConnectionTestController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(ConnectionTestController.class);

--- a/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ExecuteSqlController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.HtmlUtils;
 
-import psiprobe.controllers.ContextHandlerController;
+import psiprobe.controllers.AbstractContextHandlerController;
 import psiprobe.model.sql.DataSourceTestInfo;
 
 import java.sql.Connection;
@@ -40,7 +40,7 @@ import javax.sql.DataSource;
  * Executes an SQL query through a given datasource to test database connectivity. Displays results
  * returned by the query.
  */
-public class ExecuteSqlController extends ContextHandlerController {
+public class ExecuteSqlController extends AbstractContextHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(ExecuteSqlController.class);

--- a/core/src/main/java/psiprobe/controllers/system/SysInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/system/SysInfoController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.system;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.beans.RuntimeInfoAccessorBean;
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.SystemInformation;
 import psiprobe.tools.SecurityUtils;
 
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates an instance of SystemInformation POJO.
  */
-public class SysInfoController extends TomcatContainerController {
+public class SysInfoController extends AbstractTomcatContainerController {
 
   /** The filter out keys. */
   private List<String> filterOutKeys = new ArrayList<>();

--- a/core/src/main/java/psiprobe/controllers/threads/ListThreadPoolsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ListThreadPoolsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.threads;
 import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.beans.ContainerListenerBean;
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.ThreadPool;
 
 import java.util.List;
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates the list of http connection thread pools.
  */
-public class ListThreadPoolsController extends TomcatContainerController {
+public class ListThreadPoolsController extends AbstractTomcatContainerController {
 
   /** The container listener bean. */
   private ContainerListenerBean containerListenerBean;

--- a/core/src/main/java/psiprobe/controllers/threads/ListThreadsController.java
+++ b/core/src/main/java/psiprobe/controllers/threads/ListThreadsController.java
@@ -13,7 +13,7 @@ package psiprobe.controllers.threads;
 import org.apache.catalina.Context;
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 import psiprobe.model.java.ThreadModel;
 import psiprobe.tools.Instruments;
 
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ListThreadsController.
  */
-public class ListThreadsController extends TomcatContainerController {
+public class ListThreadsController extends AbstractTomcatContainerController {
 
   @Override
   protected ModelAndView handleRequestInternal(HttpServletRequest request,

--- a/core/src/main/java/psiprobe/controllers/truststore/TrustStoreController.java
+++ b/core/src/main/java/psiprobe/controllers/truststore/TrustStoreController.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.web.servlet.ModelAndView;
 
-import psiprobe.controllers.TomcatContainerController;
+import psiprobe.controllers.AbstractTomcatContainerController;
 
 import java.io.FileInputStream;
 import java.security.KeyStore;
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Creates an instance of SystemInformation POJO.
  */
-public class TrustStoreController extends TomcatContainerController {
+public class TrustStoreController extends AbstractTomcatContainerController {
 
   /** The Constant Logger. */
   private static final Logger logger = LoggerFactory.getLogger(TrustStoreController.class);

--- a/core/src/main/java/psiprobe/tools/logging/commons/AbstractLoggerAccessorVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/AbstractLoggerAccessorVisitor.java
@@ -18,7 +18,7 @@ import psiprobe.tools.logging.log4j.Log4JLoggerAccessor;
 /**
  * The Class LoggerAccessorVisitor.
  */
-public abstract class LoggerAccessorVisitor extends DefaultAccessor {
+public abstract class AbstractLoggerAccessorVisitor extends DefaultAccessor {
 
   /**
    * Visit.

--- a/core/src/main/java/psiprobe/tools/logging/commons/GetAllDestinationsVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/GetAllDestinationsVisitor.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * The Class GetAllDestinationsVisitor.
  */
-public class GetAllDestinationsVisitor extends LoggerAccessorVisitor {
+public class GetAllDestinationsVisitor extends AbstractLoggerAccessorVisitor {
 
   /** The destinations. */
   private final List<LogDestination> destinations = new ArrayList<>();

--- a/core/src/main/java/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
+++ b/core/src/main/java/psiprobe/tools/logging/commons/GetSingleDestinationVisitor.java
@@ -17,7 +17,7 @@ import psiprobe.tools.logging.log4j.Log4JLoggerAccessor;
 /**
  * The Class GetSingleDestinationVisitor.
  */
-public class GetSingleDestinationVisitor extends LoggerAccessorVisitor {
+public class GetSingleDestinationVisitor extends AbstractLoggerAccessorVisitor {
 
   /** The log index. */
   private final String logIndex;

--- a/core/src/test/java/psiprobe/beans/stats/listeners/FlapListenerTests.java
+++ b/core/src/test/java/psiprobe/beans/stats/listeners/FlapListenerTests.java
@@ -13,7 +13,7 @@ package psiprobe.beans.stats.listeners;
 import org.junit.Assert;
 import org.junit.Test;
 
-import psiprobe.beans.stats.listeners.FlapListener;
+import psiprobe.beans.stats.listeners.AbstractFlapListener;
 import psiprobe.beans.stats.listeners.StatsCollectionEvent;
 
 /**
@@ -209,7 +209,7 @@ public class FlapListenerTests {
    *
    * @see MockFlapEvent
    */
-  public static class MockFlapListener extends FlapListener {
+  public static class MockFlapListener extends AbstractFlapListener {
 
     /** The threshold. */
     private final long threshold;

--- a/core/src/test/java/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
+++ b/core/src/test/java/psiprobe/beans/stats/listeners/ThresholdListenerTests.java
@@ -14,7 +14,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import psiprobe.beans.stats.listeners.StatsCollectionEvent;
-import psiprobe.beans.stats.listeners.ThresholdListener;
+import psiprobe.beans.stats.listeners.AbstractThresholdListener;
 
 /**
  * The Class ThresholdListenerTests.
@@ -107,7 +107,7 @@ public class ThresholdListenerTests {
    *
    * @see MockThresholdEvent
    */
-  public static class MockThresholdListener extends ThresholdListener {
+  public static class MockThresholdListener extends AbstractThresholdListener {
 
     /** The threshold. */
     private final long threshold;

--- a/core/src/test/java/psiprobe/controllers/apps/NoSelfContextHandlerControllerImpl.java
+++ b/core/src/test/java/psiprobe/controllers/apps/NoSelfContextHandlerControllerImpl.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.controllers.apps;
 
-public class NoSelfContextHandlerControllerImpl extends NoSelfContextHandlerController {
+public class NoSelfContextHandlerControllerImpl extends AbstractNoSelfContextHandlerController {
 
   @Override
   protected void executeAction(String contextName) throws Exception {


### PR DESCRIPTION
Considered good java practice and will help in migration to spring annotations.