### PR TITLE
[controller] Abstract LogHandlerController and separate followedFileInfo object

### DIFF
--- a/core/src/main/java/psiprobe/controllers/logs/AbstractLogHandlerController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/AbstractLogHandlerController.java
@@ -23,12 +23,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * The Class LogHandlerController.
+ * The Class AbstractLogHandlerController.
  */
-public class LogHandlerController extends ParameterizableViewController {
+public abstract class AbstractLogHandlerController extends ParameterizableViewController {
 
   /** The Constant logger. */
-  private static final Logger logger = LoggerFactory.getLogger(LogHandlerController.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractLogHandlerController.class);
 
   /** The log resolver. */
   private LogResolverBean logResolver;
@@ -93,10 +93,7 @@ public class LogHandlerController extends ParameterizableViewController {
    * @return the model and view
    * @throws Exception the exception
    */
-  protected ModelAndView handleLogFile(HttpServletRequest request, HttpServletResponse response,
-      LogDestination logDest) throws Exception {
-
-    return new ModelAndView(getViewName()).addObject("log", logDest);
-  }
+  protected abstract ModelAndView handleLogFile(HttpServletRequest request, HttpServletResponse response,
+      LogDestination logDest) throws Exception;
 
 }

--- a/core/src/main/java/psiprobe/controllers/logs/ChangeLogLevelController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/ChangeLogLevelController.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class ChangeLogLevelController.
  */
-public class ChangeLogLevelController extends LogHandlerController {
+public class ChangeLogLevelController extends AbstractLogHandlerController {
 
   @Override
   protected ModelAndView handleLogFile(HttpServletRequest request, HttpServletResponse response,

--- a/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/DownloadLogController.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class DownloadLogController.
  */
-public class DownloadLogController extends LogHandlerController {
+public class DownloadLogController extends AbstractLogHandlerController {
 
   /** The Constant logger. */
   private static final Logger logger = LoggerFactory.getLogger(DownloadLogController.class);

--- a/core/src/main/java/psiprobe/controllers/logs/FollowController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/FollowController.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * The Class FollowController.
  */
-public class FollowController extends LogHandlerController {
+public class FollowController extends AbstractLogHandlerController {
 
   @Override
   protected ModelAndView handleLogFile(HttpServletRequest request, HttpServletResponse response,

--- a/core/src/main/java/psiprobe/controllers/logs/FollowedFileInfoController.java
+++ b/core/src/main/java/psiprobe/controllers/logs/FollowedFileInfoController.java
@@ -14,24 +14,18 @@ import org.springframework.web.servlet.ModelAndView;
 
 import psiprobe.tools.logging.LogDestination;
 
-import java.io.File;
-import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * The Class SetupFollowController.
+ * The Class FollowAjaxController.
  */
-public class SetupFollowController extends AbstractLogHandlerController {
+public class FollowedFileInfoController extends AbstractLogHandlerController {
 
   @Override
   protected ModelAndView handleLogFile(HttpServletRequest request, HttpServletResponse response,
       LogDestination logDest) throws Exception {
-
-    File logFile = logDest.getFile();
-    List<LogDestination> sources = getLogResolver().getLogSources(logFile);
-    return new ModelAndView(getViewName()).addObject("log", logDest).addObject("sources", sources);
+    return new ModelAndView(getViewName()).addObject("log", logDest);
   }
 
 }

--- a/core/src/test/java/psiprobe/controllers/logs/LogHandlerControllerTest.java
+++ b/core/src/test/java/psiprobe/controllers/logs/LogHandlerControllerTest.java
@@ -20,11 +20,46 @@ import com.codebox.bean.JavaBeanTester;
 public class LogHandlerControllerTest {
 
   /**
-   * Javabean tester.
+   * Javabean tester change log level.
+   */
+  public void javabeanTesterChangeLogLevel() {
+    JavaBeanTester.builder(ChangeLogLevelController.class)
+        .skip("applicationContext", "supportedMethods").test();
+  }
+
+  /**
+   * Javabean tester download log.
    */
   @Test
-  public void javabeanTester() {
-    JavaBeanTester.builder(LogHandlerController.class)
+  public void javabeanTesterDownloadLog() {
+    JavaBeanTester.builder(DownloadLogController.class)
+        .skip("applicationContext", "supportedMethods").test();
+  }
+
+  /**
+   * Javabean tester follow.
+   */
+  @Test
+  public void javabeanTesterFollow() {
+    JavaBeanTester.builder(FollowController.class)
+        .skip("applicationContext", "supportedMethods").test();
+  }
+
+  /**
+   * Javabean tester followed file info.
+   */
+  @Test
+  public void javabeanTesterFollowedFileInfo() {
+    JavaBeanTester.builder(FollowedFileInfoController.class)
+        .skip("applicationContext", "supportedMethods").test();
+  }
+
+  /**
+   * Javabean tester setup follow.
+   */
+  @Test
+  public void javabeanTesterSetupFollow() {
+    JavaBeanTester.builder(SetupFollowController.class)
         .skip("applicationContext", "supportedMethods").test();
   }
 

--- a/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-controllers.xml
@@ -450,7 +450,7 @@
 		<property name="viewName" value="ajax/follow"/>
 	</bean>
 
-	<bean name="/logs/ff_info.ajax" class="psiprobe.controllers.logs.LogHandlerController">
+	<bean name="/logs/ff_info.ajax" class="psiprobe.controllers.logs.FollowedFileInfoController">
 		<property name="logResolver" ref="logResolver"/>
 		<property name="viewName" value="ajax/followed_file_info"/>
 	</bean>


### PR DESCRIPTION
prep work for annotation based spring.  We need to move away from sharing objects which makes code mush more clear.