### PR TITLE
[spring] Switch datasource accessor to string based due to separation of tomcat needs

### DIFF
--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -51,7 +51,7 @@ public class ResourceResolverBean implements ResourceResolver {
       + "java:comp/env/";
 
   /** The datasource mappers. */
-  private List<DatasourceAccessor> datasourceMappers;
+  private List<String> datasourceMappers;
 
   @Override
   public List<ApplicationResource> getApplicationResources() throws NamingException {
@@ -141,7 +141,9 @@ public class ResourceResolverBean implements ResourceResolver {
         String jndiName = resolveJndiName(resource.getName(), global);
         Object obj = ctx.lookup(jndiName);
         resource.setLookedUp(true);
-        for (DatasourceAccessor accessor : datasourceMappers) {
+        for (String accessorString : datasourceMappers) {
+          logger.debug("Looking up datasource adapter: {}", accessorString);
+          DatasourceAccessor accessor = (DatasourceAccessor) Class.forName(accessorString).newInstance();
           dataSourceInfo = accessor.getInfo(obj);
           if (dataSourceInfo != null) {
             break;
@@ -174,7 +176,9 @@ public class ResourceResolverBean implements ResourceResolver {
       String jndiName = resolveJndiName(resourceName, context == null);
       Object obj = ctx.lookup(jndiName);
       try {
-        for (DatasourceAccessor accessor : datasourceMappers) {
+        for (String accessorString : datasourceMappers) {
+          logger.debug("Resetting datasource adapter: {}", accessorString);
+          DatasourceAccessor accessor = (DatasourceAccessor) Class.forName(accessorString).newInstance();
           if (accessor.reset(obj)) {
             return true;
           }
@@ -220,7 +224,7 @@ public class ResourceResolverBean implements ResourceResolver {
    *
    * @return the datasource mappers
    */
-  public List<DatasourceAccessor> getDatasourceMappers() {
+  public List<String> getDatasourceMappers() {
     return datasourceMappers;
   }
 
@@ -229,7 +233,7 @@ public class ResourceResolverBean implements ResourceResolver {
    *
    * @param datasourceMappers the new datasource mappers
    */
-  public void setDatasourceMappers(List<DatasourceAccessor> datasourceMappers) {
+  public void setDatasourceMappers(List<String> datasourceMappers) {
     this.datasourceMappers = datasourceMappers;
   }
 

--- a/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
+++ b/web/src/main/webapp/WEB-INF/spring-probe-resources.xml
@@ -38,18 +38,18 @@
 	<bean id="defaultResourceResolver" class="psiprobe.beans.ResourceResolverBean">
 		<property name="datasourceMappers">
 			<list>
-				<bean class="psiprobe.beans.BoneCpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.C3P0DatasourceAccessor"/>
-				<bean class="psiprobe.beans.DbcpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.Dbcp2DatasourceAccessor"/>
-				<bean class="psiprobe.beans.Tomcat7DbcpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.Tomcat8DbcpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.Tomcat85DbcpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.Tomcat9DbcpDatasourceAccessor"/>
-				<bean class="psiprobe.beans.TomcatJdbcPoolDatasourceAccessor"/>
-				<bean class="psiprobe.beans.OracleDatasourceAccessor"/>
-				<bean class="psiprobe.beans.OracleUcpDatasourceAssessor"/>
-				<bean class="psiprobe.beans.OpenEjbManagedDatasourceAccessor"/>
+				<value>psiprobe.beans.BoneCpDatasourceAccessor</value>
+				<value>psiprobe.beans.C3P0DatasourceAccessor</value>
+				<value>psiprobe.beans.DbcpDatasourceAccessor</value>
+				<value>psiprobe.beans.Dbcp2DatasourceAccessor</value>
+				<value>psiprobe.beans.Tomcat7DbcpDatasourceAccessor</value>
+				<value>psiprobe.beans.Tomcat8DbcpDatasourceAccessor</value>
+				<value>psiprobe.beans.Tomcat85DbcpDatasourceAccessor</value>
+				<value>psiprobe.beans.Tomcat9DbcpDatasourceAccessor</value>
+				<value>psiprobe.beans.TomcatJdbcPoolDatasourceAccessor</value>
+				<value>psiprobe.beans.OracleDatasourceAccessor</value>
+				<value>psiprobe.beans.OracleUcpDatasourceAssessor</value>
+				<value>psiprobe.beans.OpenEjbManagedDatasourceAccessor</value>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
When switching to spring annotations, we cannot have circular logic (ie
core requiring the tomcat modules).  Therefore, switching this to string
based so it ports with all working as expected.