### PR TITLE
[jdbc] Uncomment check on jdbc version

### DIFF
--- a/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
+++ b/core/src/main/java/psiprobe/controllers/sql/ConnectionTestController.java
@@ -86,8 +86,8 @@ public class ConnectionTestController extends AbstractContextHandlerController {
               md.getDriverName());
           addDbMetaDataEntry(dbMetaData, "probe.jsp.dataSourceTest.dbMetaData.jdbcDriverVersion",
               md.getDriverVersion());
-          // addDbMetaDataEntry(dbMetaData, "probe.jsp.dataSourceTest.dbMetaData.jdbcVersion",
-          // String.valueOf(md.getJDBCMajorVersion()));
+          addDbMetaDataEntry(dbMetaData, "probe.jsp.dataSourceTest.dbMetaData.jdbcVersion",
+              String.valueOf(md.getJDBCMajorVersion()));
 
           return new ModelAndView(getViewName(), "dbMetaData", dbMetaData);
         }


### PR DESCRIPTION
This was commented out.  No history explains why.  It works so added it back.