### PR TITLE
[jboss] Replace JBOSS DTD with jboss-web 6.0 xsd since we support 6 / 7

### DIFF
--- a/web/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/web/src/main/webapp/WEB-INF/jboss-web.xml
@@ -11,8 +11,7 @@
     PURPOSE.
 
 -->
-<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN"
-		"http://www.jboss.org/j2ee/dtd/jboss-web_4_0.dtd">
-<jboss-web>
-	<security-domain>java:/jaas/probe</security-domain>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd" version="6.0">
+    <security-domain>java:/jaas/probe</security-domain>
 </jboss-web>


### PR DESCRIPTION
Version 6 was called 3.0 for a while thus naming we still have.  Schema
looks like it was 6 right away as it was the web profile of jbossAS 6.