### PR TITLE
[sbean] Add session solution using class simpleName going forwards for tomcat 8+

### DIFF
--- a/core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -240,8 +240,8 @@ public final class ApplicationUtils {
         Object info = MethodUtils.invokeMethod(session, "getInfo", null);
         sbean.setInfo(String.valueOf(info));
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        logger.debug("Cannot determine session info");
-        logger.trace("", e);
+        sbean.setInfo(session.getClass().getSimpleName());
+        logger.trace("Cannot determine session info for tomcat 8+", e);
       }
 
       boolean sessionSerializable = true;


### PR DESCRIPTION
A lot of classes with getInfo() defined in tomcat are being removed.  The reason is that since java 5, java has had available Class().getSimpleName() which is equivalent for the most part.  So for tomcat 7, still trying the old way since I got that going but for all remaining versions simply grabbing the simple class name.