### PR TITLE
[jsp] Remove unnecessary taglibs

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/ajax/cluster/requests.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/cluster/requests.jsp
@@ -11,7 +11,6 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 
 <span class="name"><spring:message code="probe.jsp.cluster.sent"/></span> ${cluster.senderNrOfRequests}

--- a/web/src/main/webapp/WEB-INF/jsp/ajax/cluster/traffic.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/cluster/traffic.jsp
@@ -11,7 +11,6 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 

--- a/web/src/main/webapp/WEB-INF/jsp/ajax/follow.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/follow.jsp
@@ -12,8 +12,6 @@
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 
 <%-- An AJAX HTML bit, representing log file content. --%>
 <c:forEach items="${lines}" var="line">

--- a/web/src/main/webapp/WEB-INF/jsp/ajax/followed_file_info.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/followed_file_info.jsp
@@ -11,7 +11,6 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 

--- a/web/src/main/webapp/WEB-INF/jsp/ajax/osinfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/osinfo.jsp
@@ -11,7 +11,6 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 

--- a/web/src/main/webapp/WEB-INF/jsp/ajax/sql/connection.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/ajax/sql/connection.jsp
@@ -12,7 +12,6 @@
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 
 <%-- An Ajax HTML snippet to display datasource connection info. --%>

--- a/web/src/main/webapp/WEB-INF/jsp/certificates.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/certificates.jsp
@@ -12,11 +12,7 @@
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <html>
 

--- a/web/src/main/webapp/WEB-INF/jsp/certificates_table.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/certificates_table.jsp
@@ -11,11 +11,9 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
-<%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <display:table class="genericTbl" style="border-spacing:0;border-collapse:separate;" name="${certs}" uid="cert" requestURI="">
 

--- a/web/src/main/webapp/WEB-INF/jsp/connectors.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/connectors.jsp
@@ -12,7 +12,6 @@
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>

--- a/web/src/main/webapp/WEB-INF/jsp/datasources.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/datasources.jsp
@@ -13,8 +13,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
-<%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <html>
 	<head>

--- a/web/src/main/webapp/WEB-INF/jsp/datasourcetest.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/datasourcetest.jsp
@@ -13,7 +13,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <html>

--- a/web/src/main/webapp/WEB-INF/jsp/errors/paramerror.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/errors/paramerror.jsp
@@ -11,7 +11,7 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 
 <html>
 	<head><title>Error</title></head>

--- a/web/src/main/webapp/WEB-INF/jsp/errors/serverversion.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/errors/serverversion.jsp
@@ -11,7 +11,7 @@
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 
 <%-- An error page to be displayed if some Probe's feature is not implemented for a particular
  version of Tomcat --%>

--- a/web/src/main/webapp/WEB-INF/jsp/memory.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/memory.jsp
@@ -13,7 +13,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <html>

--- a/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
@@ -13,7 +13,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 
 <%-- Displays a list of servlets of a particular web application or all web applications --%>
 

--- a/web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
@@ -10,14 +10,12 @@
     PURPOSE.
 
 --%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
-
-<%@ page contentType="text/html;charset=UTF-8" language="java" session="false" %>
 <html>
 	<head>
 		<title><spring:message code="probe.jsp.title.jsps" arguments="${param.webapp}"/></title>

--- a/web/src/main/webapp/WEB-INF/jsp/sysinfo.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/sysinfo.jsp
@@ -14,7 +14,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
-<%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@ taglib uri="https://github.com/psi-probe/psi-probe/jsp/tags" prefix="probe" %>
 
 <%-- Displays various system information including System.properties. This page helps to evaluate


### PR DESCRIPTION
certain taglibs not used on the jsp pages themselves are not necessary and only confuse usage.