### PR TITLE
[pool] Add patch to boneCp in case pool returns null which is allowed - Fixes #405

### DIFF
--- a/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/BoneCpDatasourceAccessor.java
@@ -46,7 +46,15 @@ public class BoneCpDatasourceAccessor implements DatasourceAccessor {
 
       dataSourceInfo = new DataSourceInfo();
       dataSourceInfo.setBusyConnections(source.getTotalLeased());
-      dataSourceInfo.setEstablishedConnections(pool.getTotalCreatedConnections());
+
+      if(pool == null) {
+        // pool is coming up null....
+        dataSourceInfo.setEstablishedConnections(source.getMinConnectionsPerPartition());
+        logger.warn("pool is null {}", source.getJdbcUrl());
+      } else {
+        dataSourceInfo.setEstablishedConnections(pool.getTotalCreatedConnections());
+      }
+
       dataSourceInfo
           .setMaxConnections(source.getPartitionCount() * source.getMaxConnectionsPerPartition());
       dataSourceInfo.setJdbcUrl(source.getJdbcUrl());


### PR DESCRIPTION
This will fix the error but doesn't likely fix overall issue.  Will request community feedback.  Will close out issue otherwise as it's now null protected.