### PR TITLE
[context] For parallel deployment of ROOT - Fixes #545

### DIFF
--- a/core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -266,6 +266,14 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
     if ("/".equals(result) || "/ROOT".equals(result)) {
       result = "";
     }
+    // For ROOT Parallel Deployment, remove "/ROOT"
+    if (result.startsWith("/ROOT##")) {
+      result = result.substring(5);
+    }
+    // For ROOT Parallel Usage, remove "/"
+    if (result.startsWith("/##")) {
+      result = result.substring(1);
+    }
     return result;
   }
 


### PR DESCRIPTION
Fix context in safe context location

ROOT##1 style is treated differently with tomcat.  Our code was adding /ROOT##1 throughout.  While it lands on disk that way, tomcat doesn't see it that way.  It's really ##1.  So while it appeared issue was fixed for non ROOT usage, it was always broken for root usage.  Now it works for ROOT usage as well as normal usage.  ROOT entries will simply show as ##1 rather than ROOT##1 as on disk.

Entirely fixed best I can tell.  Please review and let me know if there are any concerns about where I fixed this.  Seems like all is ok but might want a little more testing tomorrow just to confirm no down side.

