### PR TITLE
[logback] Update deprecated rollingpolicy

### DIFF
--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -21,12 +21,11 @@
       <charset>utf-8</charset>
       <pattern>%d{HH:mm:ss.SSS} %-5level {%thread} [%logger{40}] %msg%n</pattern>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <fileNamePattern>${probe.log.path}/archive/probe-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
       <maxHistory>10</maxHistory>
-      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-        <maxFileSize>20MB</maxFileSize>
-      </timeBasedFileNamingAndTriggeringPolicy>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+      <maxFileSize>20MB</maxFileSize>
     </rollingPolicy>
   </appender>
 


### PR DESCRIPTION
Note that logback still spits out the error as they internally used deprecated class.  This has been fixed [here](https://github.com/qos-ch/logback/commit/39c7ab9510c4f48ef3fcbef248aac380d3b58235).  No idea when this will be released.  New style is for 1.1.7 and 1.1.8 logback which applies to our 1.1.8 usage.  Warning will go away upon next logback release.