### PR TITLE
[ci] Move datasource accessors into their own package

### DIFF
--- a/core/src/main/java/psiprobe/ProbeConfig.java
+++ b/core/src/main/java/psiprobe/ProbeConfig.java
@@ -144,18 +144,20 @@ public class ProbeConfig extends WebMvcConfigurerAdapter {
   public List<String> getDefaultRes() {
     logger.info("Instantiated datasourceMappers");
     List<String> list = new ArrayList<>();
-    list.add("psiprobe.beans.BoneCpDatasourceAccessor");
-    list.add("psiprobe.beans.C3P0DatasourceAccessor");
-    list.add("psiprobe.beans.DbcpDatasourceAccessor");
-    list.add("psiprobe.beans.Dbcp2DatasourceAccessor");
-    list.add("psiprobe.beans.Tomcat7DbcpDatasourceAccessor");
-    list.add("psiprobe.beans.Tomcat8DbcpDatasourceAccessor");
-    list.add("psiprobe.beans.Tomcat85DbcpDatasourceAccessor");
-    list.add("psiprobe.beans.Tomcat9DbcpDatasourceAccessor");
-    list.add("psiprobe.beans.TomcatJdbcPoolDatasourceAccessor");
-    list.add("psiprobe.beans.OracleDatasourceAccessor");
-    list.add("psiprobe.beans.OracleUcpDatasourceAssessor");
-    list.add("psiprobe.beans.OpenEjbManagedDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.BoneCpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.C3P0DatasourceAccessor");
+    list.add("psiprobe.beans.accessors.DbcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.Dbcp2DatasourceAccessor");
+    list.add("psiprobe.beans.accessors.HikariCpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.Tomcat7DbcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.Tomcat8DbcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.Tomcat85DbcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.Tomcat9DbcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.TomcatJdbcPoolDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.OracleDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.OracleUcpDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.OpenEjbManagedDatasourceAccessor");
+    list.add("psiprobe.beans.accessors.ViburCpDatasourceAccessor");
     return list;
   }
 

--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -16,6 +16,8 @@ import org.apache.catalina.core.StandardServer;
 import org.apache.commons.modeler.Registry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.ApplicationResource;
 import psiprobe.model.DataSourceInfo;
 

--- a/core/src/main/java/psiprobe/beans/accessors/BoneCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/BoneCpDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import com.jolbox.bonecp.BoneCP;
 import com.jolbox.bonecp.BoneCPDataSource;

--- a/core/src/main/java/psiprobe/beans/accessors/C3P0DatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/C3P0DatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 

--- a/core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import psiprobe.model.DataSourceInfo;
 

--- a/core/src/main/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessor.java
@@ -8,30 +8,30 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.tomcat.jdbc.pool.DataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 import psiprobe.model.DataSourceInfo;
 
 /**
- * Datasource accessor for tomcat.
+ * DBCP2 datasource abstraction layer.
  */
-public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
+public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
-      DataSource source = (DataSource) resource;
+      BasicDataSource source = (BasicDataSource) resource;
       dataSourceInfo = new DataSourceInfo();
       dataSourceInfo.setBusyConnections(source.getNumActive());
       dataSourceInfo.setEstablishedConnections(source.getNumIdle() + source.getNumActive());
-      dataSourceInfo.setMaxConnections(source.getMaxActive());
+      dataSourceInfo.setMaxConnections(source.getMaxTotal());
       dataSourceInfo.setJdbcUrl(source.getUrl());
       dataSourceInfo.setUsername(source.getUsername());
       dataSourceInfo.setResettable(false);
-      dataSourceInfo.setType("tomcat-jdbc");
+      dataSourceInfo.setType("commons-dbcp2");
     }
     return dataSourceInfo;
   }
@@ -43,8 +43,7 @@ public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public boolean canMap(Object resource) {
-    return "org.apache.tomcat.jdbc.pool.DataSource".equals(resource.getClass().getName())
-        && resource instanceof DataSource;
+    return "org.apache.commons.dbcp2.BasicDataSource".equals(resource.getClass().getName())
+        && resource instanceof BasicDataSource;
   }
-
 }

--- a/core/src/main/java/psiprobe/beans/accessors/DbcpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/DbcpDatasourceAccessor.java
@@ -8,16 +8,16 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp.BasicDataSource;
 
 import psiprobe.model.DataSourceInfo;
 
 /**
- * The Class Tomcat85DbcpDatasourceAccessor.
+ * DBCP datasource abstraction layer.
  */
-public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
+public class DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {
@@ -27,11 +27,11 @@ public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
       dataSourceInfo = new DataSourceInfo();
       dataSourceInfo.setBusyConnections(source.getNumActive());
       dataSourceInfo.setEstablishedConnections(source.getNumIdle() + source.getNumActive());
-      dataSourceInfo.setMaxConnections(source.getMaxTotal());
+      dataSourceInfo.setMaxConnections(source.getMaxActive());
       dataSourceInfo.setJdbcUrl(source.getUrl());
       dataSourceInfo.setUsername(source.getUsername());
       dataSourceInfo.setResettable(false);
-      dataSourceInfo.setType("tomcat-dbcp2");
+      dataSourceInfo.setType("commons-dbcp");
     }
     return dataSourceInfo;
   }
@@ -43,8 +43,7 @@ public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public boolean canMap(Object resource) {
-    return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource".equals(resource.getClass().getName())
+    return "org.apache.commons.dbcp.BasicDataSource".equals(resource.getClass().getName())
         && resource instanceof BasicDataSource;
   }
-
 }

--- a/core/src/main/java/psiprobe/beans/accessors/HikariCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/HikariCpDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import java.lang.management.ManagementFactory;
 

--- a/core/src/main/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.apache.openejb.resource.jdbc.managed.local.ManagedDataSource;
 import org.apache.tomcat.jdbc.pool.DataSourceProxy;

--- a/core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import oracle.jdbc.pool.OracleConnectionCacheManager;
 import oracle.jdbc.pool.OracleDataSource;

--- a/core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import oracle.ucp.jdbc.JDBCConnectionPoolStatistics;
 import oracle.ucp.jdbc.PoolDataSource;
@@ -17,7 +17,7 @@ import psiprobe.model.DataSourceInfo;
 /**
  * Accesses an Oracle Universal Connection Pool (UCP) resource.
  */
-public class OracleUcpDatasourceAssessor implements DatasourceAccessor {
+public class OracleUcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {

--- a/core/src/main/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessor.java
@@ -8,30 +8,30 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+import org.apache.tomcat.jdbc.pool.DataSource;
 
 import psiprobe.model.DataSourceInfo;
 
 /**
- * The Class Tomcat8DbcpDatasourceAccessor.
+ * Datasource accessor for tomcat.
  */
-public class Tomcat8DbcpDatasourceAccessor implements DatasourceAccessor {
+public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
-      BasicDataSource source = (BasicDataSource) resource;
+      DataSource source = (DataSource) resource;
       dataSourceInfo = new DataSourceInfo();
       dataSourceInfo.setBusyConnections(source.getNumActive());
       dataSourceInfo.setEstablishedConnections(source.getNumIdle() + source.getNumActive());
-      dataSourceInfo.setMaxConnections(source.getMaxTotal());
+      dataSourceInfo.setMaxConnections(source.getMaxActive());
       dataSourceInfo.setJdbcUrl(source.getUrl());
       dataSourceInfo.setUsername(source.getUsername());
       dataSourceInfo.setResettable(false);
-      dataSourceInfo.setType("tomcat-dbcp2");
+      dataSourceInfo.setType("tomcat-jdbc");
     }
     return dataSourceInfo;
   }
@@ -43,8 +43,8 @@ public class Tomcat8DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public boolean canMap(Object resource) {
-    return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource".equals(resource.getClass().getName())
-        && resource instanceof BasicDataSource;
+    return "org.apache.tomcat.jdbc.pool.DataSource".equals(resource.getClass().getName())
+        && resource instanceof DataSource;
   }
 
 }

--- a/core/src/main/java/psiprobe/beans/accessors/ViburCpDatasourceAccessor.java
+++ b/core/src/main/java/psiprobe/beans/accessors/ViburCpDatasourceAccessor.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import java.lang.management.ManagementFactory;
 

--- a/core/src/main/java/psiprobe/beans/accessors/package-info.java
+++ b/core/src/main/java/psiprobe/beans/accessors/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+/**
+ * Psi Probe Accessors Package.
+ */
+package psiprobe.beans.accessors;

--- a/core/src/test/java/psiprobe/beans/accessors/BoneCpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/BoneCpDatasourceAccessorTest.java
@@ -8,25 +8,29 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.commons.dbcp.BasicDataSource;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
+import mockit.Mocked;
+import psiprobe.beans.accessors.BoneCpDatasourceAccessor;
+
 /**
- * The Class DbcpDatasourceAccessorTest.
+ * The Class BoneCpDatasourceAccessorTest.
  */
-public class DbcpDatasourceAccessorTest {
+public class BoneCpDatasourceAccessorTest {
 
     /** The accessor. */
-    DbcpDatasourceAccessor accessor;
+    BoneCpDatasourceAccessor accessor;
 
     /** The source. */
-    BasicDataSource source;
+    @Mocked
+    BoneCPDataSource source;
 
     /** The bad source. */
     ComboPooledDataSource badSource;
@@ -36,8 +40,7 @@ public class DbcpDatasourceAccessorTest {
      */
     @Before
     public void before() {
-        accessor = new DbcpDatasourceAccessor();
-        source = new BasicDataSource();
+        accessor = new BoneCpDatasourceAccessor();
         badSource = new ComboPooledDataSource();
     }
 

--- a/core/src/test/java/psiprobe/beans/accessors/BoneCpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/BoneCpDatasourceAccessorTest.java
@@ -18,7 +18,6 @@ import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 import mockit.Mocked;
-import psiprobe.beans.accessors.BoneCpDatasourceAccessor;
 
 /**
  * The Class BoneCpDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/C3P0DatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/C3P0DatasourceAccessorTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.mchange.v2.c3p0.jboss.C3P0PooledDataSource;
 
-import psiprobe.beans.accessors.C3P0DatasourceAccessor;
-
 /**
  * The Class C3P0DatasourceAccessorTest.
  */

--- a/core/src/test/java/psiprobe/beans/accessors/C3P0DatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/C3P0DatasourceAccessorTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.mchange.v2.c3p0.jboss.C3P0PooledDataSource;
+
+import psiprobe.beans.accessors.C3P0DatasourceAccessor;
+
+/**
+ * The Class C3P0DatasourceAccessorTest.
+ */
+public class C3P0DatasourceAccessorTest {
+
+    /** The accessor. */
+    C3P0DatasourceAccessor accessor;
+
+    /** The source. */
+    ComboPooledDataSource source;
+
+    /** The bad source. */
+    C3P0PooledDataSource badSource;
+
+    /**
+     * Before.
+     */
+    @Before
+    public void before() {
+        accessor = new C3P0DatasourceAccessor();
+        source = new ComboPooledDataSource();
+        badSource = new C3P0PooledDataSource();
+    }
+
+    /**
+     * Can map test.
+     */
+    @Test
+    public void canMapTest() {
+        Assert.assertTrue(accessor.canMap(source));
+    }
+
+    /**
+     * Cannot map test.
+     */
+    @Test
+    public void cannotMapTest() {
+        Assert.assertFalse(accessor.canMap(badSource));
+    }
+
+    /**
+     * Gets the info test.
+     *
+     * @return the info test
+     * @throws Exception the exception
+     */
+    @Test
+    public void getInfoTest() throws Exception {
+        accessor.getInfo(source);
+    }
+
+}

--- a/core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import psiprobe.beans.accessors.Dbcp2DatasourceAccessor;
-
 /**
  * The Class Dbcp2DatasourceAccessorTest.
  */

--- a/core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Assert;
@@ -16,6 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import psiprobe.beans.accessors.Dbcp2DatasourceAccessor;
 
 /**
  * The Class Dbcp2DatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/DbcpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/DbcpDatasourceAccessorTest.java
@@ -8,31 +8,27 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.openejb.resource.jdbc.managed.local.ManagedDataSource;
+import org.apache.commons.dbcp.BasicDataSource;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import mockit.Mocked;
-import mockit.Tested;
+import psiprobe.beans.accessors.DbcpDatasourceAccessor;
 
 /**
- * The Class OpenEjbManagedDatasourceAccessorTest.
+ * The Class DbcpDatasourceAccessorTest.
  */
-public class OpenEjbManagedDatasourceAccessorTest {
+public class DbcpDatasourceAccessorTest {
 
     /** The accessor. */
-    @Tested
-    OpenEjbManagedDatasourceAccessor accessor;
+    DbcpDatasourceAccessor accessor;
 
     /** The source. */
-    @Mocked
-    ManagedDataSource source;
+    BasicDataSource source;
 
     /** The bad source. */
     ComboPooledDataSource badSource;
@@ -42,14 +38,14 @@ public class OpenEjbManagedDatasourceAccessorTest {
      */
     @Before
     public void before() {
-        accessor = new OpenEjbManagedDatasourceAccessor();
+        accessor = new DbcpDatasourceAccessor();
+        source = new BasicDataSource();
         badSource = new ComboPooledDataSource();
     }
 
     /**
      * Can map test.
      */
-    @Ignore
     @Test
     public void canMapTest() {
         Assert.assertTrue(accessor.canMap(source));

--- a/core/src/test/java/psiprobe/beans/accessors/DbcpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/DbcpDatasourceAccessorTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import psiprobe.beans.accessors.DbcpDatasourceAccessor;
-
 /**
  * The Class DbcpDatasourceAccessorTest.
  */

--- a/core/src/test/java/psiprobe/beans/accessors/HikariCpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/HikariCpDatasourceAccessorTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+
+import mockit.Mocked;
+
+/**
+ * The Class HikariCpDatasourceAccessorTest.
+ */
+public class HikariCpDatasourceAccessorTest {
+
+    /** The accessor. */
+    HikariCpDatasourceAccessor accessor;
+
+    /** The source. */
+    @Mocked
+    HikariDataSource source;
+
+    /** The bad source. */
+    ComboPooledDataSource badSource;
+
+    /**
+     * Before.
+     */
+    @Before
+    public void before() {
+        accessor = new HikariCpDatasourceAccessor();
+        badSource = new ComboPooledDataSource();
+    }
+
+    /**
+     * Can map test.
+     */
+    @Test
+    public void canMapTest() {
+        Assert.assertTrue(accessor.canMap(source));
+    }
+
+    /**
+     * Cannot map test.
+     */
+    @Test
+    public void cannotMapTest() {
+        Assert.assertFalse(accessor.canMap(badSource));
+    }
+
+    /**
+     * Gets the info test.
+     *
+     * @return the info test
+     * @throws Exception the exception
+     */
+    @Ignore
+    @Test
+    public void getInfoTest() throws Exception {
+        accessor.getInfo(source);
+    }
+
+}

--- a/core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
@@ -20,7 +20,6 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 import mockit.Mocked;
 import mockit.Tested;
-import psiprobe.beans.accessors.OpenEjbManagedDatasourceAccessor;
 
 /**
  * The Class OpenEjbManagedDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
@@ -8,50 +8,49 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import java.sql.SQLException;
-import java.util.Properties;
-
+import org.apache.openejb.resource.jdbc.managed.local.ManagedDataSource;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import mockit.Expectations;
 import mockit.Mocked;
-import oracle.jdbc.pool.OracleDataSource;
+import mockit.Tested;
+import psiprobe.beans.accessors.OpenEjbManagedDatasourceAccessor;
 
 /**
- * The Class OracleDatasourceAccessorTest.
+ * The Class OpenEjbManagedDatasourceAccessorTest.
  */
-public class OracleDatasourceAccessorTest {
+public class OpenEjbManagedDatasourceAccessorTest {
 
     /** The accessor. */
-    OracleDatasourceAccessor accessor;
+    @Tested
+    OpenEjbManagedDatasourceAccessor accessor;
 
     /** The source. */
     @Mocked
-    OracleDataSource source;
+    ManagedDataSource source;
 
     /** The bad source. */
     ComboPooledDataSource badSource;
 
     /**
      * Before.
-     *
-     * @throws SQLException the SQL exception
      */
     @Before
-    public void before() throws SQLException {
-        accessor = new OracleDatasourceAccessor();
+    public void before() {
+        accessor = new OpenEjbManagedDatasourceAccessor();
         badSource = new ComboPooledDataSource();
     }
 
     /**
      * Can map test.
      */
+    @Ignore
     @Test
     public void canMapTest() {
         Assert.assertTrue(accessor.canMap(source));
@@ -73,12 +72,6 @@ public class OracleDatasourceAccessorTest {
      */
     @Test
     public void getInfoTest() throws Exception {
-        new Expectations() {
-            {
-                source.getConnectionCacheProperties();
-                result = new Properties();
-            }
-        };
         accessor.getInfo(source);
     }
 

--- a/core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -22,7 +22,6 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
 import oracle.jdbc.pool.OracleDataSource;
-import psiprobe.beans.accessors.OracleDatasourceAccessor;
 
 /**
  * The Class OracleDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -8,42 +8,45 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
+
+import java.sql.SQLException;
+import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import oracle.ucp.jdbc.PoolDataSourceImpl;
-import oracle.ucp.jdbc.PoolXADataSourceImpl;
+import mockit.Expectations;
+import mockit.Mocked;
+import oracle.jdbc.pool.OracleDataSource;
+import psiprobe.beans.accessors.OracleDatasourceAccessor;
 
 /**
- * The Class OracleUcpDatasourceAssessorTest.
+ * The Class OracleDatasourceAccessorTest.
  */
-public class OracleUcpDatasourceAssessorTest {
+public class OracleDatasourceAccessorTest {
 
     /** The accessor. */
-    OracleUcpDatasourceAssessor accessor;
+    OracleDatasourceAccessor accessor;
 
     /** The source. */
-    PoolDataSourceImpl source;
+    @Mocked
+    OracleDataSource source;
 
-    PoolXADataSourceImpl xaSource;
-    
     /** The bad source. */
     ComboPooledDataSource badSource;
 
     /**
      * Before.
+     *
+     * @throws SQLException the SQL exception
      */
     @Before
-    public void before() {
-        accessor = new OracleUcpDatasourceAssessor();
-        source = new PoolDataSourceImpl();
-        xaSource = new PoolXADataSourceImpl();
+    public void before() throws SQLException {
+        accessor = new OracleDatasourceAccessor();
         badSource = new ComboPooledDataSource();
     }
 
@@ -53,14 +56,6 @@ public class OracleUcpDatasourceAssessorTest {
     @Test
     public void canMapTest() {
         Assert.assertTrue(accessor.canMap(source));
-    }
-
-    /**
-     * Can map XA test.
-     */
-    @Test
-    public void canMapXATest() {
-        Assert.assertTrue(accessor.canMap(xaSource));
     }
 
     /**
@@ -79,6 +74,12 @@ public class OracleUcpDatasourceAssessorTest {
      */
     @Test
     public void getInfoTest() throws Exception {
+        new Expectations() {
+            {
+                source.getConnectionCacheProperties();
+                result = new Properties();
+            }
+        };
         accessor.getInfo(source);
     }
 

--- a/core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -18,7 +18,6 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 import oracle.ucp.jdbc.PoolDataSourceImpl;
 import oracle.ucp.jdbc.PoolXADataSourceImpl;
-import psiprobe.beans.accessors.OracleUcpDatasourceAccessor;
 
 /**
  * The Class OracleUcpDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -8,29 +8,31 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.jolbox.bonecp.BoneCPDataSource;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import mockit.Mocked;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+import oracle.ucp.jdbc.PoolXADataSourceImpl;
+import psiprobe.beans.accessors.OracleUcpDatasourceAccessor;
 
 /**
- * The Class BoneCpDatasourceAccessorTest.
+ * The Class OracleUcpDatasourceAccessorTest.
  */
-public class BoneCpDatasourceAccessorTest {
+public class OracleUcpDatasourceAccessorTest {
 
     /** The accessor. */
-    BoneCpDatasourceAccessor accessor;
+    OracleUcpDatasourceAccessor accessor;
 
     /** The source. */
-    @Mocked
-    BoneCPDataSource source;
+    PoolDataSourceImpl source;
 
+    PoolXADataSourceImpl xaSource;
+    
     /** The bad source. */
     ComboPooledDataSource badSource;
 
@@ -39,7 +41,9 @@ public class BoneCpDatasourceAccessorTest {
      */
     @Before
     public void before() {
-        accessor = new BoneCpDatasourceAccessor();
+        accessor = new OracleUcpDatasourceAccessor();
+        source = new PoolDataSourceImpl();
+        xaSource = new PoolXADataSourceImpl();
         badSource = new ComboPooledDataSource();
     }
 
@@ -49,6 +53,14 @@ public class BoneCpDatasourceAccessorTest {
     @Test
     public void canMapTest() {
         Assert.assertTrue(accessor.canMap(source));
+    }
+
+    /**
+     * Can map XA test.
+     */
+    @Test
+    public void canMapXATest() {
+        Assert.assertTrue(accessor.canMap(xaSource));
     }
 
     /**

--- a/core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 import mockit.Mocked;
-import psiprobe.beans.accessors.TomcatJdbcPoolDatasourceAccessor;
 
 /**
  * The Class TomcatJdbcPoolDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
@@ -8,7 +8,7 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.junit.Assert;
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 import mockit.Mocked;
+import psiprobe.beans.accessors.TomcatJdbcPoolDatasourceAccessor;
 
 /**
  * The Class TomcatJdbcPoolDatasourceAccessorTest.

--- a/core/src/test/java/psiprobe/beans/accessors/ViburCpDatasourceAccessorTest.java
+++ b/core/src/test/java/psiprobe/beans/accessors/ViburCpDatasourceAccessorTest.java
@@ -8,37 +8,41 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.vibur.dbcp.ViburDBCPDataSource;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-import com.mchange.v2.c3p0.jboss.C3P0PooledDataSource;
+
+import mockit.Expectations;
+import mockit.Mocked;
 
 /**
- * The Class C3P0DatasourceAccessorTest.
+ * The Class ViburCpDatasourceAccessorTest.
  */
-public class C3P0DatasourceAccessorTest {
+public class ViburCpDatasourceAccessorTest {
 
     /** The accessor. */
-    C3P0DatasourceAccessor accessor;
+    ViburCpDatasourceAccessor accessor;
 
     /** The source. */
-    ComboPooledDataSource source;
+    @Mocked
+    ViburDBCPDataSource source;
 
     /** The bad source. */
-    C3P0PooledDataSource badSource;
+    ComboPooledDataSource badSource;
 
     /**
      * Before.
      */
     @Before
     public void before() {
-        accessor = new C3P0DatasourceAccessor();
-        source = new ComboPooledDataSource();
-        badSource = new C3P0PooledDataSource();
+        accessor = new ViburCpDatasourceAccessor();
+        badSource = new ComboPooledDataSource();
     }
 
     /**
@@ -63,8 +67,15 @@ public class C3P0DatasourceAccessorTest {
      * @return the info test
      * @throws Exception the exception
      */
+    @Ignore
     @Test
     public void getInfoTest() throws Exception {
+        new Expectations() {
+          {
+            source.getJmxName();
+            result = "viburJmx";
+          }
+        };
         accessor.getInfo(source);
     }
 

--- a/tomcat70adapter/src/main/java/psiprobe/beans/accessors/Tomcat7DbcpDatasourceAccessor.java
+++ b/tomcat70adapter/src/main/java/psiprobe/beans/accessors/Tomcat7DbcpDatasourceAccessor.java
@@ -12,7 +12,6 @@ package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
 
-import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**

--- a/tomcat70adapter/src/main/java/psiprobe/beans/accessors/Tomcat7DbcpDatasourceAccessor.java
+++ b/tomcat70adapter/src/main/java/psiprobe/beans/accessors/Tomcat7DbcpDatasourceAccessor.java
@@ -8,10 +8,11 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
 
+import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**

--- a/tomcat70adapter/src/main/java/psiprobe/beans/accessors/package-info.java
+++ b/tomcat70adapter/src/main/java/psiprobe/beans/accessors/package-info.java
@@ -11,4 +11,4 @@
 /**
  * Psi-Probe Beans Package.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;

--- a/tomcat80adapter/src/main/java/psiprobe/beans/accessors/Tomcat8DbcpDatasourceAccessor.java
+++ b/tomcat80adapter/src/main/java/psiprobe/beans/accessors/Tomcat8DbcpDatasourceAccessor.java
@@ -12,7 +12,6 @@ package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
-import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**

--- a/tomcat80adapter/src/main/java/psiprobe/beans/accessors/Tomcat8DbcpDatasourceAccessor.java
+++ b/tomcat80adapter/src/main/java/psiprobe/beans/accessors/Tomcat8DbcpDatasourceAccessor.java
@@ -8,16 +8,17 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
+import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**
- * DBCP2 datasource abstraction layer.
+ * The Class Tomcat8DbcpDatasourceAccessor.
  */
-public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
+public class Tomcat8DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {
@@ -31,7 +32,7 @@ public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
       dataSourceInfo.setJdbcUrl(source.getUrl());
       dataSourceInfo.setUsername(source.getUsername());
       dataSourceInfo.setResettable(false);
-      dataSourceInfo.setType("commons-dbcp2");
+      dataSourceInfo.setType("tomcat-dbcp2");
     }
     return dataSourceInfo;
   }
@@ -43,7 +44,8 @@ public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public boolean canMap(Object resource) {
-    return "org.apache.commons.dbcp2.BasicDataSource".equals(resource.getClass().getName())
+    return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource".equals(resource.getClass().getName())
         && resource instanceof BasicDataSource;
   }
+
 }

--- a/tomcat80adapter/src/main/java/psiprobe/beans/accessors/package-info.java
+++ b/tomcat80adapter/src/main/java/psiprobe/beans/accessors/package-info.java
@@ -11,4 +11,4 @@
 /**
  * Psi-Probe Beans Package.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;

--- a/tomcat85adapter/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
+++ b/tomcat85adapter/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
@@ -12,7 +12,6 @@ package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
-import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**

--- a/tomcat85adapter/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
+++ b/tomcat85adapter/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
@@ -8,16 +8,17 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
+import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**
- * The Class Tomcat9DbcpDatasourceAccessor.
+ * The Class Tomcat85DbcpDatasourceAccessor.
  */
-public class Tomcat9DbcpDatasourceAccessor implements DatasourceAccessor {
+public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {

--- a/tomcat85adapter/src/main/java/psiprobe/beans/accessors/package-info.java
+++ b/tomcat85adapter/src/main/java/psiprobe/beans/accessors/package-info.java
@@ -11,4 +11,4 @@
 /**
  * Psi-Probe Beans Package.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;

--- a/tomcat90adapter/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
+++ b/tomcat90adapter/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
@@ -8,16 +8,17 @@
  * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
+import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**
- * DBCP datasource abstraction layer.
+ * The Class Tomcat9DbcpDatasourceAccessor.
  */
-public class DbcpDatasourceAccessor implements DatasourceAccessor {
+public class Tomcat9DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public DataSourceInfo getInfo(Object resource) throws Exception {
@@ -27,11 +28,11 @@ public class DbcpDatasourceAccessor implements DatasourceAccessor {
       dataSourceInfo = new DataSourceInfo();
       dataSourceInfo.setBusyConnections(source.getNumActive());
       dataSourceInfo.setEstablishedConnections(source.getNumIdle() + source.getNumActive());
-      dataSourceInfo.setMaxConnections(source.getMaxActive());
+      dataSourceInfo.setMaxConnections(source.getMaxTotal());
       dataSourceInfo.setJdbcUrl(source.getUrl());
       dataSourceInfo.setUsername(source.getUsername());
       dataSourceInfo.setResettable(false);
-      dataSourceInfo.setType("commons-dbcp");
+      dataSourceInfo.setType("tomcat-dbcp2");
     }
     return dataSourceInfo;
   }
@@ -43,7 +44,8 @@ public class DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
   public boolean canMap(Object resource) {
-    return "org.apache.commons.dbcp.BasicDataSource".equals(resource.getClass().getName())
+    return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource".equals(resource.getClass().getName())
         && resource instanceof BasicDataSource;
   }
+
 }

--- a/tomcat90adapter/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
+++ b/tomcat90adapter/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
@@ -12,7 +12,6 @@ package psiprobe.beans.accessors;
 
 import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 
-import psiprobe.beans.accessors.DatasourceAccessor;
 import psiprobe.model.DataSourceInfo;
 
 /**

--- a/tomcat90adapter/src/main/java/psiprobe/beans/accessors/package-info.java
+++ b/tomcat90adapter/src/main/java/psiprobe/beans/accessors/package-info.java
@@ -11,4 +11,4 @@
 /**
  * Psi-Probe Beans Package.
  */
-package psiprobe.beans;
+package psiprobe.beans.accessors;


### PR DESCRIPTION
Hikari/Vibur both configured for use and added additional unit tests.

Moved all datasource accessors inot their own package in core and tomcat modules to match.

Corrected some accesser naming issues.