### PR TITLE
[leak] Restore JspWriter outside try / catch as it is not a leak

### DIFF
--- a/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
+++ b/core/src/main/java/psiprobe/jsp/VisualScoreTag.java
@@ -92,9 +92,9 @@ public class VisualScoreTag extends BodyTagSupport {
 
       String buf = calculateSuffix(body);
 
-      try (JspWriter out = bc.getEnclosingWriter()) {
-        out.print(buf);
-      }
+      // No resource leak here, attempting to fix results in output being already closed
+      JspWriter out = bc.getEnclosingWriter();
+      out.print(buf);
     } catch (IOException e) {
       logger.trace("", e);
       throw new JspException("Error:IOException while writing to client" + e.getMessage());


### PR DESCRIPTION
Trying to wrap this way will close the output and cause exception and
inibility to startup.