### PR TITLE
Cleanup certificate information

### DIFF
--- a/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
+++ b/core/src/main/java/psiprobe/beans/ResourceResolverBean.java
@@ -152,6 +152,7 @@ public class ResourceResolverBean implements ResourceResolver {
           return;
         }
         String jndiName = resolveJndiName(resource.getName(), global);
+        logger.info("reading resource jndi name: {}", jndiName);
         Object obj = ctx.lookup(jndiName);
         resource.setLookedUp(true);
         for (String accessorString : datasourceMappers) {

--- a/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
+++ b/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
@@ -80,7 +80,7 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
         for (SSLHostConfigInfo sslHostConfigInfo : sslHostConfigInfos) {
           if (sslHostConfigInfo.getTruststoreType() != null) {
             certs = getCertificates(sslHostConfigInfo.getTruststoreType(),
-            sslHostConfigInfo.getTruststoreFile(), sslHostConfigInfo.getTruststorePassword());
+              sslHostConfigInfo.getTruststoreFile(), sslHostConfigInfo.getTruststorePassword());
             sslHostConfigInfo.setTrustStoreCerts(certs);
           }
 
@@ -88,8 +88,8 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
           for (CertificateInfo certificateInfo : certificateInfos) {
             if (certificateInfo.getCertificateKeystoreType() != null) {
               certs = getCertificates(certificateInfo.getCertificateKeystoreType(),
-              certificateInfo.getCertificateKeystoreFile(),
-              certificateInfo.getCertificateKeystorePassword());
+                certificateInfo.getCertificateKeystoreFile(),
+                certificateInfo.getCertificateKeystorePassword());
               certificateInfo.setKeyStoreCerts(certs);
             }
           }

--- a/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
+++ b/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
@@ -78,16 +78,20 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
 
         List<SSLHostConfigInfo> sslHostConfigInfos = info.getSslHostConfigInfos();
         for (SSLHostConfigInfo sslHostConfigInfo : sslHostConfigInfos) {
-          certs = getCertificates(sslHostConfigInfo.getTruststoreType(),
-              sslHostConfigInfo.getTruststoreFile(), sslHostConfigInfo.getTruststorePassword());
-          sslHostConfigInfo.setTrustStoreCerts(certs);
+          if (sslHostConfigInfo.getTruststoreType() != null) {
+            certs = getCertificates(sslHostConfigInfo.getTruststoreType(),
+            sslHostConfigInfo.getTruststoreFile(), sslHostConfigInfo.getTruststorePassword());
+            sslHostConfigInfo.setTrustStoreCerts(certs);
+          }
 
           List<CertificateInfo> certificateInfos = sslHostConfigInfo.getCertificateInfos();
           for (CertificateInfo certificateInfo : certificateInfos) {
-            certs = getCertificates(certificateInfo.getCertificateKeystoreType(),
-                certificateInfo.getCertificateKeystoreFile(),
-                certificateInfo.getCertificateKeystorePassword());
-            certificateInfo.setKeyStoreCerts(certs);
+            if (certificateInfo.getCertificateKeystoreType() != null) {
+              certs = getCertificates(certificateInfo.getCertificateKeystoreType(),
+              certificateInfo.getCertificateKeystoreFile(),
+              certificateInfo.getCertificateKeystorePassword());
+              certificateInfo.setKeyStoreCerts(certs);
+            }
           }
         }
       }
@@ -231,16 +235,18 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
           MethodUtils.invokeMethod(protocol, "getDefaultSSLHostConfigName", null);
       if (defaultSSLHostConfigName == null) {
         logger.error("Cannot determine defaultSSLHostConfigName");
+        return info;
       }
       info.setDefaultSSLHostConfigName(String.valueOf(defaultSSLHostConfigName));
       new SSLHostConfigHelper(protocol, info);
     } catch (NoSuchMethodException e) {
       logger.trace("", e);
-      // We are using Tomcat 7, fill in the old way
+      // We are using Tomcat 7 or 8, fill in the old way
       OldConnectorInfo oldConnectorInfo = new OldConnectorInfo();
       BeanUtils.copyProperties(oldConnectorInfo, protocol);
-      oldConnectorInfo.setName(ObjectName.unquote(protocol.getName()));
-      info = oldConnectorInfo;
+
+      info.setDefaultSSLHostConfigName("_default_");
+      info.setSslHostConfigInfos(oldConnectorInfo.getSslHostConfigInfos());
     }
 
     return info;

--- a/core/src/main/java/psiprobe/model/certificates/OldConnectorInfo.java
+++ b/core/src/main/java/psiprobe/model/certificates/OldConnectorInfo.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
 package psiprobe.model.certificates;
 
 import java.util.ArrayList;


### PR DESCRIPTION
We needed null checks in case only truststore or keystore is used.  This logic matched original and applies in both original and new.  Also, we didn't need to replace ConnectorInfo but rather just use proper fields as the remainder will then read it as expected.