### PR TITLE
[certs] Patch null check with check on file instead

### DIFF
--- a/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
+++ b/core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
@@ -78,7 +78,7 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
 
         List<SSLHostConfigInfo> sslHostConfigInfos = info.getSslHostConfigInfos();
         for (SSLHostConfigInfo sslHostConfigInfo : sslHostConfigInfos) {
-          if (sslHostConfigInfo.getTruststoreType() != null) {
+          if (sslHostConfigInfo.getTruststoreFile() != null) {
             certs = getCertificates(sslHostConfigInfo.getTruststoreType(),
               sslHostConfigInfo.getTruststoreFile(), sslHostConfigInfo.getTruststorePassword());
             sslHostConfigInfo.setTrustStoreCerts(certs);
@@ -86,7 +86,7 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
 
           List<CertificateInfo> certificateInfos = sslHostConfigInfo.getCertificateInfos();
           for (CertificateInfo certificateInfo : certificateInfos) {
-            if (certificateInfo.getCertificateKeystoreType() != null) {
+            if (certificateInfo.getCertificateKeystoreFile() != null) {
               certs = getCertificates(certificateInfo.getCertificateKeystoreType(),
                 certificateInfo.getCertificateKeystoreFile(),
                 certificateInfo.getCertificateKeystorePassword());


### PR DESCRIPTION
Why because type is not required and is defaulted later so that is a bad
check.  while keystore gets set elsewhere truststore does not and will
eventually get whatever keystore has so it's best to check that we are
pointed to a file.