### PR TITLE
[ci] Use internal commons fileupload instead of separate copy

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -179,11 +179,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>compile</scope>

--- a/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -22,14 +22,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.catalina.Context;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.fileupload.servlet.ServletRequestContext;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.tomcat.util.http.fileupload.FileItem;
+import org.apache.tomcat.util.http.fileupload.FileItemFactory;
+import org.apache.tomcat.util.http.fileupload.FileUploadBase;
+import org.apache.tomcat.util.http.fileupload.disk.DiskFileItemFactory;
+import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
+import org.apache.tomcat.util.http.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -97,7 +98,7 @@ public class CopySingleFileController extends AbstractTomcatContainerController 
       upload.setSizeMax(-1);
       upload.setHeaderEncoding(StandardCharsets.UTF_8.name());
       try {
-        List<FileItem> fileItems = upload.parseRequest(request);
+        List<FileItem> fileItems = upload.parseRequest(new ServletRequestContext(request));
         for (FileItem fi : fileItems) {
           if (!fi.isFormField()) {
             if (fi.getName() != null && fi.getName().length() > 0) {

--- a/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -11,14 +11,14 @@
 package psiprobe.controllers.deploy;
 
 import org.apache.catalina.Context;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.fileupload.servlet.ServletRequestContext;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.tomcat.util.http.fileupload.FileItem;
+import org.apache.tomcat.util.http.fileupload.FileItemFactory;
+import org.apache.tomcat.util.http.fileupload.FileUploadBase;
+import org.apache.tomcat.util.http.fileupload.disk.DiskFileItemFactory;
+import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
+import org.apache.tomcat.util.http.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -77,7 +77,7 @@ public class UploadWarController extends AbstractTomcatContainerController {
       upload.setSizeMax(-1);
       upload.setHeaderEncoding(StandardCharsets.UTF_8.name());
       try {
-        List<FileItem> fileItems = upload.parseRequest(request);
+        List<FileItem> fileItems = upload.parseRequest(new ServletRequestContext(request));
         for (FileItem fi : fileItems) {
           if (!fi.isFormField()) {
             if (fi.getName() != null && fi.getName().length() > 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,6 @@
                 <version>3.2.2</version>
             </dependency>
             <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>1.3.2</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.5</version>


### PR DESCRIPTION
After all, we are using tomcat and it comes with this baked in.