### PR TITLE
[quartz] Remove obsolete skipUpdateCheck - fixes #1053

### DIFF
--- a/core/src/main/java/psiprobe/ProbeConfig.java
+++ b/core/src/main/java/psiprobe/ProbeConfig.java
@@ -974,7 +974,6 @@ public class ProbeConfig extends WebMvcConfigurerAdapter {
     // Add Properties
     Properties properties = new Properties();
     properties.setProperty("org.quartz.scheduler.instanceName", "ProbeScheduler");
-    properties.setProperty("org.quartz.scheduler.skipUpdateCheck", "true");
     properties.setProperty("org.quartz.threadPool.threadCount", "5");
     properties.setProperty("org.quartz.threadPool.threadNamePrefix", "Probe_Quartz");
     bean.setQuartzProperties(properties);

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.0</version> <!-- TODO: Version 4.0.0-b05 is for java 8 only-->
             </dependency>
             <dependency>
                 <groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
quartz 2.3.0 has removed their update check so this setting can now be
removed.

fixes #1053 