### PR TITLE
Feature/java util logging filehandler

### DIFF
--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessor.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.tools.logging.jdk;
+
+import java.io.File;
+
+import psiprobe.tools.Instruments;
+
+public class Jdk14FileHandlerAccessor extends Jdk14HandlerAccessor {
+
+	private static final int LATEST_FILE_INDEX = 0;
+
+	/**
+	 * Currently, we only access the latest log file with index 0.
+	 */
+	@Override
+	public File getFile() {
+		String pattern = (String) Instruments.getField(getTarget(), "pattern");
+		String logFilePath = pattern.replace("%g", String.valueOf(LATEST_FILE_INDEX));
+		return new File(logFilePath);
+	}
+}

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessor.java
@@ -23,8 +23,10 @@ public class Jdk14FileHandlerAccessor extends Jdk14HandlerAccessor {
 	 */
 	@Override
 	public File getFile() {
-		String pattern = (String) Instruments.getField(getTarget(), "pattern");
-		String logFilePath = pattern.replace("%g", String.valueOf(LATEST_FILE_INDEX));
-		return new File(logFilePath);
+		File[] files = (File[]) Instruments.getField(getTarget(), "files");
+		if (files == null || files.length == 0) {
+			throw new IllegalStateException("File handler does not manage any files");
+		}
+		return files[LATEST_FILE_INDEX];
 	}
 }

--- a/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/jdk/Jdk14LoggerAccessor.java
@@ -191,10 +191,13 @@ public class Jdk14LoggerAccessor extends DefaultAccessor {
         throw new IllegalArgumentException("handler is null");
       }
       Jdk14HandlerAccessor handlerAccessor = null;
-      if ("org.apache.juli.FileHandler".equals(handler.getClass().getName())) {
+      String className = handler.getClass().getName();
+      if ("org.apache.juli.FileHandler".equals(className)) {
         handlerAccessor = new JuliHandlerAccessor();
-      } else if ("java.util.logging.ConsoleHandler".equals(handler.getClass().getName())) {
+      } else if ("java.util.logging.ConsoleHandler".equals(className)) {
         handlerAccessor = new Jdk14HandlerAccessor();
+      } else if ( "java.util.logging.FileHandler".equals(className)) {
+        handlerAccessor = new Jdk14FileHandlerAccessor();
       }
 
       if (handlerAccessor != null) {

--- a/core/src/test/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessorTest.java
+++ b/core/src/test/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessorTest.java
@@ -1,0 +1,39 @@
+package psiprobe.tools.logging.jdk;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.util.logging.FileHandler;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import psiprobe.model.Application;
+
+public class Jdk14FileHandlerAccessorTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Test
+	public void getFile() throws Exception {
+		Jdk14FileHandlerAccessor handlerAccessor = new Jdk14FileHandlerAccessor();
+		handlerAccessor.setLoggerAccessor(new Jdk14LoggerAccessor());
+
+		String testPath = folder.newFolder().getAbsolutePath();
+		FileHandler target = new FileHandler(testPath + "test-%g.log", 1024, 3);
+
+		handlerAccessor.setTarget(target);
+		handlerAccessor.setIndex(Integer.toString(0));
+		Application testApplication = new Application();
+		handlerAccessor.setApplication(testApplication);
+
+		File file = handlerAccessor.getFile();
+
+		assertThat(file.getAbsolutePath(), equalTo(testPath + "test-0.log") );
+
+	}
+
+}

--- a/core/src/test/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessorTest.java
+++ b/core/src/test/java/psiprobe/tools/logging/jdk/Jdk14FileHandlerAccessorTest.java
@@ -1,3 +1,13 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
 package psiprobe.tools.logging.jdk;
 
 import static org.hamcrest.CoreMatchers.equalTo;


### PR DESCRIPTION
Fixes #363 for java.util.logging.FileHandler

Note: Did not change Jdk14HandlerAccessor's interface, so only the latest log file is taken into account, even if multiple files are rolled over by the FileHandler.