### PR TITLE
[secure] Add suggestions for Xstream to secure usage

### DIFF
--- a/core/src/main/java/psiprobe/controllers/BeanToXmlController.java
+++ b/core/src/main/java/psiprobe/controllers/BeanToXmlController.java
@@ -68,7 +68,10 @@ public class BeanToXmlController extends AbstractController {
       if (modelAndView.getModel() != null) {
         TransportableModel tm = new TransportableModel();
         tm.putAll(modelAndView.getModel());
-        new XStream().toXML(tm, response.getWriter());
+        XStream xstream = new XStream();
+        xstream.allowTypesByWildcard(new String[] {"psibrobe.controllers.**"});
+        XStream.setupDefaultSecurity(xstream);
+        xstream.toXML(tm, response.getWriter());
       }
     }
     return null;

--- a/core/src/main/java/psiprobe/model/stats/StatsCollection.java
+++ b/core/src/main/java/psiprobe/model/stats/StatsCollection.java
@@ -244,7 +244,10 @@ public class StatsCollection implements InitializingBean, DisposableBean, Applic
     try {
       shiftFiles(0);
       try (OutputStream os = Files.newOutputStream(makeFile().toPath())) {
-        new XStream().toXML(statsData, os);
+        XStream xstream = new XStream();
+        xstream.allowTypesByWildcard(new String[] {"psibrobe.model.stats.**"});
+        XStream.setupDefaultSecurity(xstream);
+        xstream.toXML(statsData, os);
       }
     } catch (Exception e) {
       logger.error("Could not write stats data to '{}'", makeFile().getAbsolutePath(), e);


### PR DESCRIPTION
warnings don't seem to go away and I am not seeing any issues.  this is essentially what is suggested as the fix so publishing in case someone else can provide further insite.