### PR TITLE
[pom] Update base tomcat to 9.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <spring-security.version>5.0.5.RELEASE</spring-security.version>
         <text.version>1.4</text.version>
         <transaction-api.version>1.3</transaction-api.version>
-        <tomcat.version>8.5.31</tomcat.version>
+        <tomcat.version>9.0.8</tomcat.version>
         <wrapper.version>3.2.3</wrapper.version>
         <xpp3_min.version>1.1.4c</xpp3_min.version>
         <xstream.version>1.4.10</xstream.version>


### PR DESCRIPTION
we were using 8.5.  While we support all currently supported, our core can safely move to 9.0.8 as we are on java 8 now.