### PR TITLE
[secure] Per nvs, add htmlEscape to param usage

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/appattributes.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appattributes.jsp
@@ -21,7 +21,7 @@
 
 	<head>
 		<title>
-			<spring:message code="probe.jsp.title.app.attributes" arguments="${param.webapp}"/>
+			<spring:message htmlEscape="true" code="probe.jsp.title.app.attributes" arguments="${param.webapp}"/>
 		</title>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='scroller.css'/>"/>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>

--- a/web/src/main/webapp/WEB-INF/jsp/appfiltermaps.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appfiltermaps.jsp
@@ -21,7 +21,7 @@
 
 	<head>
 		<title>
-			<spring:message code="probe.jsp.title.app.filtermaps" arguments="${param.webapp}"/>
+			<spring:message htmlEscape="true" code="probe.jsp.title.app.filtermaps" arguments="${param.webapp}"/>
 		</title>
 	</head>
 

--- a/web/src/main/webapp/WEB-INF/jsp/appfilters.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appfilters.jsp
@@ -22,7 +22,7 @@
 
 	<head>
 		<title>
-			<spring:message code="probe.jsp.title.app.filters" arguments="${param.webapp}"/>
+			<spring:message htmlEscape="true" code="probe.jsp.title.app.filters" arguments="${param.webapp}"/>
 		</title>
 	</head>
 

--- a/web/src/main/webapp/WEB-INF/jsp/appinitparams.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appinitparams.jsp
@@ -21,7 +21,7 @@
 
 	<head>
 		<title>
-			<spring:message code="probe.jsp.title.app.initParams" arguments="${param.webapp}"/>
+			<spring:message htmlEscape="true" code="probe.jsp.title.app.initParams" arguments="${param.webapp}"/>
 		</title>
 	</head>
 

--- a/web/src/main/webapp/WEB-INF/jsp/appsummary.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/appsummary.jsp
@@ -20,7 +20,7 @@
 <html>
 	<head>
 		<title>
-			<spring:message code="probe.jsp.title.app.summary" arguments="${param.webapp}"/>
+			<spring:message htmlEscape="true" code="probe.jsp.title.app.summary" arguments="${param.webapp}"/>
 		</title>
 	</head>
 
@@ -44,7 +44,7 @@
 				<script type="text/javascript" src="<c:url value='/js/behaviour.js'/>"></script>
 
 				<c:set var="confirmMessage">
-					<spring:message code="probe.jsp.app.summary.undeploy.confirm" arguments="${param.webapp}"/>
+					<spring:message htmlEscape="true" code="probe.jsp.app.summary.undeploy.confirm" arguments="${param.webapp}"/>
 				</c:set>
 				<ul class="options">
 					<li id="appSurfTo">

--- a/web/src/main/webapp/WEB-INF/jsp/datasourcetest.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/datasourcetest.jsp
@@ -18,7 +18,7 @@
 <html>
 
 	<head>
-		<title><spring:message code="probe.jsp.title.testDataSource" arguments="${param.webapp},${param.resource}"/></title>
+		<title><spring:message htmlEscape="true" code="probe.jsp.title.testDataSource" arguments="${param.webapp},${param.resource}"/></title>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='datasourcetest.css'/>"/>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='scroller.css'/>"/>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>

--- a/web/src/main/webapp/WEB-INF/jsp/decorators/application.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/decorators/application.jsp
@@ -17,7 +17,7 @@
 
 <div class="verticalMenu">
 	<div>
-		<p><spring:message code="probe.jsp.app.nav.title" arguments="${param.webapp}"/></p>
+		<p><spring:message htmlEscape="true" code="probe.jsp.app.nav.title" arguments="${param.webapp}"/></p>
 	</div>
 	<ul>
 		<li>

--- a/web/src/main/webapp/WEB-INF/jsp/resources.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/resources.jsp
@@ -19,7 +19,7 @@
 <html>
 
 	<head>
-		<title><spring:message code="probe.jsp.title.resources" arguments="${param.webapp}"/></title>
+		<title><spring:message htmlEscape="true" code="probe.jsp.title.resources" arguments="${param.webapp}"/></title>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='resources.css'/>"/>
 	</head>
 

--- a/web/src/main/webapp/WEB-INF/jsp/servletmaps.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/servletmaps.jsp
@@ -26,7 +26,7 @@
 					<spring:message code="probe.jsp.title.servletmaps.all"/>
 				</c:when>
 				<c:otherwise>
-					<spring:message code="probe.jsp.title.servletmaps.app" arguments="${param.webapp}"/>
+					<spring:message htmlEscape="true" code="probe.jsp.title.servletmaps.app" arguments="${param.webapp}"/>
 				</c:otherwise>
 			</c:choose>
 		</title>

--- a/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/servlets.jsp
@@ -25,7 +25,7 @@
 					<spring:message code="probe.jsp.title.servlets.all"/>
 				</c:when>
 				<c:otherwise>
-					<spring:message code="probe.jsp.title.servlets.app" arguments="${param.webapp}"/>
+					<spring:message htmlEscape="true" code="probe.jsp.title.servlets.app" arguments="${param.webapp}"/>
 				</c:otherwise>
 			</c:choose>
 		</title>

--- a/web/src/main/webapp/WEB-INF/jsp/sessions.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/sessions.jsp
@@ -27,7 +27,7 @@
 				<title><spring:message code="probe.jsp.title.sessions.all"/></title>
 			</c:when>
 			<c:otherwise>
-				<title><spring:message code="probe.jsp.title.sessions" arguments="${param.webapp}"/></title>
+				<title><spring:message htmlEscape="true" code="probe.jsp.title.sessions" arguments="${param.webapp}"/></title>
 			</c:otherwise>
 		</c:choose>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>

--- a/web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
@@ -18,7 +18,7 @@
 
 <html>
 	<head>
-		<title><spring:message code="probe.jsp.title.jsps" arguments="${param.webapp}"/></title>
+		<title><spring:message htmlEscape="true" code="probe.jsp.title.jsps" arguments="${param.webapp}"/></title>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>
 		<script type="text/javascript" src="<c:url value='/js/scriptaculous/scriptaculous.js'/>"></script>
 	</head>

--- a/web/src/main/webapp/WEB-INF/jsp/view_jsp_source.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/view_jsp_source.jsp
@@ -17,7 +17,7 @@
 
 <html>
 	<head>
-		<title><spring:message code="probe.jsp.title.viewsource" arguments="${param.source}"/></title>
+		<title><spring:message htmlEscape="true" code="probe.jsp.title.viewsource" arguments="${param.source}"/></title>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='syntax.css'/>"/>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='scroller.css'/>"/>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>

--- a/web/src/main/webapp/WEB-INF/jsp/view_xml_conf.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/view_xml_conf.jsp
@@ -19,7 +19,7 @@
 
 <html>
 	<head>
-		<title><spring:message code="probe.jsp.title.app.viewXMLConf" arguments="${param.webapp},${fileDesc}"/></title>
+		<title><spring:message htmlEscape="true" code="probe.jsp.title.app.viewXMLConf" arguments="${param.webapp},${fileDesc}"/></title>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='syntax.css'/>"/>
 		<link type="text/css" rel="stylesheet" href="${pageContext.request.contextPath}<spring:theme code='scroller.css'/>"/>
 		<script type="text/javascript" src="<c:url value='/js/prototype.js'/>"></script>


### PR DESCRIPTION
param.webapp is the name of the webapp.  This comes from server not client but nvs cannot figure that out.  Unless user can inject into parameters which is already blocked, this should not be a problem.  However, to ensure we make nvs trust our usage, this causes no degrade in how things work.