### PR TITLE
[log4j2] Change invokemethod to get property

### DIFF
--- a/core/src/main/java/psiprobe/tools/logging/log4j2/Log4J2AppenderAccessor.java
+++ b/core/src/main/java/psiprobe/tools/logging/log4j2/Log4J2AppenderAccessor.java
@@ -76,7 +76,7 @@ public class Log4J2AppenderAccessor extends AbstractLogDestination {
 
   @Override
   public File getFile() {
-    String fileName = (String) invokeMethod(getTarget(), "getFileName", null, null);
+    String fileName = (String) getProperty(getTarget(), "fileName", null);
     if (fileName != null) {
       return new File(fileName);
     } else {


### PR DESCRIPTION
This one supresses thrown exception into a less likely method call and is preferred over using invoke method.