### PR TITLE
Partial jmockit 1.48 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <jcommon.version>1.0.24</jcommon.version>
         <jfreechart.version>1.0.19</jfreechart.version> <!-- TODO: Upgrade to 1.5.0 -->
         <jhighlight.version>1.0.3</jhighlight.version>
-        <jmockit.version>1.47</jmockit.version>
+        <jmockit.version>1.48</jmockit.version>
         <jna.version>5.4.0</jna.version>
         <jsp-api.version>2.3.6</jsp-api.version>
         <jsr305.version>3.0.2</jsr305.version>

--- a/tomcat70adapter/pom.xml
+++ b/tomcat70adapter/pom.xml
@@ -36,6 +36,9 @@
   </scm>
 
     <properties>
+        <!-- TODO: Downcast jmockit to 1.47 as tests break with 1.48 -->
+        <jmockit.version>1.47</jmockit.version>
+
         <tomcat.version>7.0.96</tomcat.version>
     </properties>
 

--- a/tomcat80adapter/pom.xml
+++ b/tomcat80adapter/pom.xml
@@ -36,6 +36,9 @@
   </scm>
 
     <properties>
+        <!-- TODO: Downcast jmockit to 1.47 as tests break with 1.48 -->
+        <jmockit.version>1.47</jmockit.version>
+
         <tomcat.version>8.0.53</tomcat.version>
     </properties>
 

--- a/tomcat85adapter/pom.xml
+++ b/tomcat85adapter/pom.xml
@@ -36,6 +36,9 @@
   </scm>
 
     <properties>
+        <!-- TODO: Downcast jmockit to 1.47 as tests break with 1.48 -->
+        <jmockit.version>1.47</jmockit.version>
+
         <tomcat.version>8.5.45</tomcat.version>
     </properties>
 

--- a/tomcat90adapter/pom.xml
+++ b/tomcat90adapter/pom.xml
@@ -36,6 +36,9 @@
   </scm>
 
     <properties>
+        <!-- TODO: Downcast jmockit to 1.47 as tests break with 1.48 -->
+        <jmockit.version>1.47</jmockit.version>
+
         <tomcat.version>9.0.24</tomcat.version>
     </properties>
 


### PR DESCRIPTION
core works fine with the upgrade but the adapters do not.  For those, drop back to 1.47 for time being.