### PR TITLE
[jfree] Upgrade to jfreechart 1.5.0 retaining 3D support

### DIFF
--- a/core/src/main/java/psiprobe/controllers/RenderChartController.java
+++ b/core/src/main/java/psiprobe/controllers/RenderChartController.java
@@ -16,14 +16,13 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.DateAxis;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.renderer.xy.XYAreaRenderer;
-import org.jfree.chart.renderer.xy.XYLine3DRenderer;
+import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.data.xy.DefaultTableXYDataset;
-import org.jfree.ui.RectangleInsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -33,6 +32,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
 import psiprobe.Utils;
 import psiprobe.beans.stats.providers.SeriesProvider;
+import psiprobe.jfreechart.XYLine3DRenderer;
 import psiprobe.model.stats.StatsCollection;
 
 /**
@@ -197,7 +197,7 @@ public class RenderChartController extends AbstractController {
 
       response.setHeader("Content-type", "image/png");
       response.getOutputStream()
-          .write(ChartUtilities.encodeAsPNG(chart.createBufferedImage(width, height)));
+          .write(ChartUtils.encodeAsPNG(chart.createBufferedImage(width, height)));
     }
 
     return null;

--- a/core/src/main/java/psiprobe/jfreechart/Effect3D.java
+++ b/core/src/main/java/psiprobe/jfreechart/Effect3D.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2016, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * -------------
+ * Effect3D.java
+ * -------------
+ * (C) Copyright 2002-2008, by Object Refinery Limited.
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 05-Nov-2002 : Version 1 (DG);
+ * 14-Nov-2002 : Modified to have independent x and y offsets (DG);
+ * 15-Sep-2019 : Copied from original Jfreechart as code obsoleted and necessary for visuals in Psi Probe without extra rework (JWL);
+ *
+ */
+
+package psiprobe.jfreechart;
+
+/**
+ * An interface that should be implemented by renderers that use a 3D effect.
+ * This allows the axes to mirror the same effect by querying the renderer.
+ */
+public interface Effect3D {
+
+    /**
+     * Returns the x-offset (in Java2D units) for the 3D effect.
+     *
+     * @return The offset.
+     */
+    public double getXOffset();
+
+    /**
+     * Returns the y-offset (in Java2D units) for the 3D effect.
+     *
+     * @return The offset.
+     */
+    public double getYOffset();
+}

--- a/core/src/main/java/psiprobe/jfreechart/XYLine3DRenderer.java
+++ b/core/src/main/java/psiprobe/jfreechart/XYLine3DRenderer.java
@@ -1,0 +1,299 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2016, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * XYLine3DRenderer.java
+ * ---------------------
+ * (C) Copyright 2005-2008, by Object Refinery Limited.
+ *
+ * Original Author:  Thomas Morgner;
+ * Contributor(s):   David Gilbert (for Object Refinery Limited);
+ *
+ * Changes
+ * -------
+ * 14-Jan-2005 : Added standard header (DG);
+ * 01-May-2007 : Fixed equals() and serialization bugs (DG);
+ * 15-Sep-2019 : Copied from original Jfreechart as code obsoleted and necessary for visuals in Psi Probe without extra rework (JWL);
+ *
+ */
+
+package psiprobe.jfreechart;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Paint;
+import java.awt.Shape;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import org.jfree.chart.event.RendererChangeEvent;
+import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.chart.util.PaintUtils;
+import org.jfree.chart.util.SerialUtils;
+
+/**
+ * A XYLineAndShapeRenderer that adds a shadow line to the graph
+ * to emulate a 3D-effect.
+ */
+public class XYLine3DRenderer extends XYLineAndShapeRenderer
+                              implements Effect3D, Serializable {
+
+    /** For serialization. */
+    private static final long serialVersionUID = 588933208243446087L;
+
+    /** The default x-offset for the 3D effect. */
+    public static final double DEFAULT_X_OFFSET = 12.0;
+
+    /** The default y-offset for the 3D effect. */
+    public static final double DEFAULT_Y_OFFSET = 8.0;
+
+    /** The default wall paint. */
+    public static final Paint DEFAULT_WALL_PAINT = new Color(0xDD, 0xDD, 0xDD);
+
+    /** The size of x-offset for the 3D effect. */
+    private double xOffset;
+
+    /** The size of y-offset for the 3D effect. */
+    private double yOffset;
+
+    /** The paint used to shade the left and lower 3D wall. */
+    private transient Paint wallPaint;
+
+    /**
+     * Creates a new renderer.
+     */
+    public XYLine3DRenderer() {
+        this.wallPaint = DEFAULT_WALL_PAINT;
+        this.xOffset = DEFAULT_X_OFFSET;
+        this.yOffset = DEFAULT_Y_OFFSET;
+    }
+
+    /**
+     * Returns the x-offset for the 3D effect.
+     *
+     * @return The 3D effect.
+     */
+    @Override
+    public double getXOffset() {
+        return this.xOffset;
+    }
+
+    /**
+     * Returns the y-offset for the 3D effect.
+     *
+     * @return The 3D effect.
+     */
+    @Override
+    public double getYOffset() {
+        return this.yOffset;
+    }
+
+    /**
+     * Sets the x-offset and sends a {@link RendererChangeEvent} to all
+     * registered listeners.
+     *
+     * @param xOffset  the x-offset.
+     */
+    public void setXOffset(double xOffset) {
+        this.xOffset = xOffset;
+        fireChangeEvent();
+    }
+
+    /**
+     * Sets the y-offset and sends a {@link RendererChangeEvent} to all
+     * registered listeners.
+     *
+     * @param yOffset  the y-offset.
+     */
+    public void setYOffset(double yOffset) {
+        this.yOffset = yOffset;
+        fireChangeEvent();
+    }
+
+    /**
+     * Returns the paint used to highlight the left and bottom wall in the plot
+     * background.
+     *
+     * @return The paint.
+     */
+    public Paint getWallPaint() {
+        return this.wallPaint;
+    }
+
+    /**
+     * Sets the paint used to hightlight the left and bottom walls in the plot
+     * background and sends a {@link RendererChangeEvent} to all registered
+     * listeners.
+     *
+     * @param paint  the paint.
+     */
+    public void setWallPaint(Paint paint) {
+        this.wallPaint = paint;
+        fireChangeEvent();
+    }
+
+    /**
+     * Returns the number of passes through the data that the renderer requires
+     * in order to draw the chart.  Most charts will require a single pass,
+     * but some require two passes.
+     *
+     * @return The pass count.
+     */
+    @Override
+    public int getPassCount() {
+        return 3;
+    }
+
+    /**
+     * Returns {@code true} if the specified pass involves drawing lines.
+     *
+     * @param pass  the pass.
+     *
+     * @return A boolean.
+     */
+    @Override
+    protected boolean isLinePass(int pass) {
+        return pass == 0 || pass == 1;
+    }
+
+    /**
+     * Returns {@code true} if the specified pass involves drawing items.
+     *
+     * @param pass  the pass.
+     *
+     * @return A boolean.
+     */
+    @Override
+    protected boolean isItemPass(int pass) {
+        return pass == 2;
+    }
+
+    /**
+     * Returns {@code true} if the specified pass involves drawing shadows.
+     *
+     * @param pass  the pass.
+     *
+     * @return A boolean.
+     */
+    protected boolean isShadowPass (int pass) {
+        return pass == 0;
+    }
+
+    /**
+     * Overrides the method in the subclass to draw a shadow in the first pass.
+     *
+     * @param g2  the graphics device.
+     * @param pass  the pass.
+     * @param series  the series index (zero-based).
+     * @param item  the item index (zero-based).
+     * @param shape  the shape.
+     */
+    @Override
+    protected void drawFirstPassShape(Graphics2D g2, int pass, int series,
+            int item, Shape shape) {
+        if (isShadowPass(pass)) {
+            if (getWallPaint() != null) {
+                g2.setStroke(getItemStroke(series, item));
+                g2.setPaint(getWallPaint());
+                g2.translate(getXOffset(), getYOffset());
+                g2.draw(shape);
+                g2.translate(-getXOffset(), -getYOffset());
+            }
+        }
+        else {
+            // now draw the real shape
+            super.drawFirstPassShape(g2, pass, series, item, shape);
+        }
+    }
+
+    /**
+     * Tests this renderer for equality with an arbitrary object.
+     *
+     * @param obj  the object ({@code null} permitted).
+     *
+     * @return A boolean.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof XYLine3DRenderer)) {
+            return false;
+        }
+        XYLine3DRenderer that = (XYLine3DRenderer) obj;
+        if (this.xOffset != that.xOffset) {
+            return false;
+        }
+        if (this.yOffset != that.yOffset) {
+            return false;
+        }
+        if (!PaintUtils.equal(this.wallPaint, that.wallPaint)) {
+            return false;
+        }
+        return super.equals(obj);
+    }
+
+    /**
+     * Provides serialization support.
+     *
+     * @param stream  the input stream.
+     *
+     * @throws IOException  if there is an I/O error.
+     * @throws ClassNotFoundException  if there is a classpath problem.
+     */
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        this.wallPaint = SerialUtils.readPaint(stream);
+    }
+
+    /**
+     * Provides serialization support.
+     *
+     * @param stream  the output stream.
+     *
+     * @throws IOException  if there is an I/O error.
+     */
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        stream.defaultWriteObject();
+        SerialUtils.writePaint(this.wallPaint, stream);
+    }
+
+}

--- a/core/src/main/java/psiprobe/jfreechart/package-info.java
+++ b/core/src/main/java/psiprobe/jfreechart/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+/**
+ * Jfreechart dropped simulated 3D support in 1.5.0.  Per authors of Jfreechart 
+ *
+ * "All the classes relating to pseudo-3D charts have been removed, as much better
+ *  3D charts are offered by Orson Charts so we prefer not to maintain the pseudo-3D
+ *  chart code within JFreeChart"
+ *
+ *  See https://github.com/jfree/jfreechart for more information.
+ *
+ *  For continued support of psi-probe and to remain on supported software, it was
+ *  decided to port this code here.  This is for internal usage only and eventually
+ *  psi-probe should follows 'authors' advice for support.
+ */
+package psiprobe.jfreechart;

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,7 @@
         <j2objc.version>1.3</j2objc.version>
         <jackson.version>2.10.0.pr2</jackson.version>
         <javabean-tester.version>2.2.0</javabean-tester.version>
-        <jcommon.version>1.0.24</jcommon.version>
-        <jfreechart.version>1.0.19</jfreechart.version> <!-- TODO: Upgrade to 1.5.0 -->
+        <jfreechart.version>1.5.0</jfreechart.version>
         <jhighlight.version>1.0.3</jhighlight.version>
         <jmockit.version>1.48</jmockit.version>
         <jna.version>5.4.0</jna.version>
@@ -635,12 +634,6 @@
                 <groupId>org.jfree</groupId>
                 <artifactId>jfreechart</artifactId>
                 <version>${jfreechart.version}</version>
-            </dependency>
-            <!-- Override jcommon used in jfreechart -->
-            <dependency>
-                <groupId>org.jfree</groupId>
-                <artifactId>jcommon</artifactId>
-                <version>${jcommon.version}</version>
             </dependency>
 
             <!-- Tanuki Wrapper -->


### PR DESCRIPTION
Jfreechart dropped the emulated 3D support.  In order to be up-to-date and retain compatibility, a new package to restore support with jfreechart has been added to psi probe.