### PR TITLE
[remove] Drop support for jboss web 7.0

### DIFF
--- a/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
+++ b/tomcat70adapter/src/main/java/psiprobe/Tomcat70ContainerAdapter.java
@@ -54,7 +54,6 @@ public class Tomcat70ContainerAdapter extends AbstractTomcatContainer {
     }
     return binding.startsWith("Apache Tomcat/7.0")
         || binding.startsWith("Apache Tomcat (TomEE)/7.0")
-        || binding.startsWith("JBoss Web/7.0")
         || binding.startsWith("NonStop(tm) Servlets For JavaServer Pages(tm) v7.0")
         || binding.startsWith("Pivotal tc") && binding.contains("/7.0");
   }

--- a/tomcat70adapter/src/test/java/psiprobe/Tomcat70ContainerAdapterTest.java
+++ b/tomcat70adapter/src/test/java/psiprobe/Tomcat70ContainerAdapterTest.java
@@ -82,15 +82,6 @@ public class Tomcat70ContainerAdapterTest {
   }
 
   /**
-   * Can bound to jboss7.
-   */
-  @Test
-  public void canBoundToJBoss7() {
-    final Tomcat70ContainerAdapter adapter = new Tomcat70ContainerAdapter();
-    assertTrue(adapter.canBoundTo("JBoss Web/7.0"));
-  }
-
-  /**
    * Can bound to nsjsp7.
    */
   @Test


### PR DESCRIPTION
jboss does not support this release any longer, it's long vulnerable and we are not going to support it either.