### PR TITLE
Remove transient hikaricp from build output

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -210,6 +210,12 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                 <exclusion>
+                      <groupId>com.zaxxer</groupId>
+                      <artifactId>HikariCP-java7</artifactId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>opensymphony</groupId>

--- a/web/src/main/webapp/META-INF/context.xml
+++ b/web/src/main/webapp/META-INF/context.xml
@@ -21,4 +21,4 @@
                     tldScan="${tomcat.util.scan.StandardJarScanFilter.jarsToScan},spring-webmvc-*.jar,displaytag-*.jar,jakarta.servlet.jsp.jstl-*.jar,sitemesh-*.jar"
                     tldSkip="jakarta.servlet.jsp.jstl-api-*.jar" />
   </JarScanner>
-</Context> 
+</Context>


### PR DESCRIPTION
quartz introduced this even though we don't need it via quartz currently.  It was also on an old copy and possibly what is causing users issues accessing their dbs.