### PR TITLE
Remove legacy support of tomcat versions

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/psi-probe-core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -523,7 +523,8 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
 
     if (paths != null) {
       for (String name : paths) {
-        boolean isJsp = name.endsWith(".jsp") || name.endsWith(".jspx") || opt.getJspConfig().isJspPage(name);
+        boolean isJsp =
+            name.endsWith(".jsp") || name.endsWith(".jspx") || opt.getJspConfig().isJspPage(name);
 
         if (isJsp) {
           JspCompilationContext jcctx =

--- a/psi-probe-core/src/main/java/psiprobe/AbstractTomcatContainer.java
+++ b/psi-probe-core/src/main/java/psiprobe/AbstractTomcatContainer.java
@@ -523,15 +523,7 @@ public abstract class AbstractTomcatContainer implements TomcatContainer {
 
     if (paths != null) {
       for (String name : paths) {
-        boolean isJsp = false;
-
-        try {
-          isJsp =
-              name.endsWith(".jsp") || name.endsWith(".jspx") || opt.getJspConfig().isJspPage(name);
-        } catch (Exception e) {
-          // XXX Tomcat 7.0.x throws JasperException otherwise this could be removed.
-          logger.info("isJspPage() thrown an error for '{}'", name, e);
-        }
+        boolean isJsp = name.endsWith(".jsp") || name.endsWith(".jspx") || opt.getJspConfig().isJspPage(name);
 
         if (isJsp) {
           JspCompilationContext jcctx =

--- a/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -381,28 +381,14 @@ public final class ApplicationUtils {
       si.setAllocationCount(sw.getCountAllocated());
       si.setErrorCount(sw.getErrorCount());
       si.setLoadTime(sw.getLoadTime());
+      // XXX: Remove with tomcat 10.1
       si.setMaxInstances(sw.getMaxInstances());
       si.setMaxTime(sw.getMaxTime());
       si.setMinTime(sw.getMinTime() == Long.MAX_VALUE ? 0 : sw.getMinTime());
       si.setProcessingTime(sw.getProcessingTime());
       si.setRequestCount(sw.getRequestCount());
-      // XXX: Deprecated and will be removed in tomcat 10.1
-      // Tomcat 7.0.72+, 8.0.37+, 8.5.5+, and 9.0.0.M10 modified from boolean to Boolean.
-      // Since SingleThreadModel deprecated in servlet 2.4 with no direct replacement,
-      // we will continue to handle as boolean. Previously calling this would have
-      // resulted in class being loaded if not already. This is why Null is returned
-      // now.
-      try {
-        Object singleThreaded = MethodUtils.invokeMethod(sw, "isSingleThreadModel");
-        if (singleThreaded == null) {
-          si.setSingleThreaded(false);
-        } else {
-          si.setSingleThreaded(Boolean.parseBoolean(String.valueOf(singleThreaded)));
-        }
-      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        logger.error("Cannot determine single threading");
-        logger.trace("", e);
-      }
+      // XXX: Remove with tomcat 10.1
+      si.setSingleThreaded(Boolean.TRUE.equals(sw.isSingleThreadModel()));
     }
     return si;
   }


### PR DESCRIPTION
- Remove support for tomcat 7, we already dropped tomcat 7 a long time ago.
- Remove support for tomcat 8 as end of life for long time and we also dropped that support long time ago.
- Remove support for earlier tomcat 8.5 or 9.0 versions as incredibly vulnerable in usage and no reason to support roughly 5 or more year old versions.