### PR TITLE
[fix] Catalina logger is wrong on timestamp

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/tools/logging/catalina/CatalinaLoggerAccessor.java
@@ -42,8 +42,7 @@ public class CatalinaLoggerAccessor extends AbstractLogDestination {
     String dir = (String) invokeMethod(getTarget(), "getDirectory", null, null);
     String prefix = (String) invokeMethod(getTarget(), "getPrefix", null, null);
     String suffix = (String) invokeMethod(getTarget(), "getSuffix", null, null);
-    boolean timestamp =
-        Boolean.parseBoolean(String.valueOf(Instruments.getField(getTarget(), "timestamp")));
+    boolean timestamp = Instruments.getField(getTarget(), "timestamp") != null;
     String date = timestamp ? new SimpleDateFormat("yyyy-MM-dd").format(new Date()) : "";
 
     File file = notNull(date, dir, prefix, suffix) ? new File(dir, prefix + date + suffix) : null;


### PR DESCRIPTION
getField isn't a true, false, null.  Its the field if it exists.  So this would be better served by simply checking not null to get true/false.