### PR TITLE
Require maven 3.9.2 and remove c3p0 from custom message that is generic in reality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <maven.compiler.testRelease>${java.test.release.version}</maven.compiler.testRelease>
 
         <!-- Maven minimum version -->
-        <maven.min-version>3.9.1</maven.min-version>
+        <maven.min-version>3.9.2</maven.min-version>
 
         <!-- Copyright -->
         <copyright>2023</copyright>

--- a/psi-probe-core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/datasources/ResetDataSourceController.java
@@ -89,7 +89,7 @@ public class ResetDataSourceController extends AbstractContextHandlerController 
       }
       if (!reset) {
         request.setAttribute("errorMessage",
-            getMessageSourceAccessor().getMessage("probe.src.reset.datasource.c3p0"));
+            getMessageSourceAccessor().getMessage("probe.src.reset.datasource"));
       }
 
     }

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages.properties
@@ -469,7 +469,7 @@ probe.src.deploy.file.notExists=Context {0} not exists
 probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 probe.src.deploy.file.notPath=The selected destination path not exists
 probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=This datasource cannot be reset
+probe.src.reset.datasource=This datasource cannot be reset
 probe.src.reset.datasource.notfound=Resource {0} does not exist
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_de.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_de.properties
@@ -469,7 +469,7 @@ probe.src.deploy.file.notExists=Der Inhalt {0} ist nicht vorhanden
 probe.src.deploy.file.failure=W\u00e4hrend des Kopierens der Datei, wurde von Tomcat ein Fehler ausgel\u00f6st: "{0}". Dies muss jedoch nicht bedeuten, dass das Deployment Ihrer Anwendung fehlgeschlagen ist. Bitte f\u00fcberprf\u00fcfen Sie den Status in der Anwendungsliste.
 probe.src.deploy.file.notPath=Der ausgew\u00e4hhlte Zielpfad existiert nicht
 probe.src.deploy.file.pathNotValid=Der ausgew\u00e4hhlte Zielpfad ist ungf\u00fcltig
-probe.src.reset.datasource.c3p0=Die Datenquelle kann nicht zur\u00fcckgesetzt werden.
+probe.src.reset.datasource=Die Datenquelle kann nicht zur\u00fcckgesetzt werden.
 probe.src.reset.datasource.notfound=Ressource {0} existiert nicht.
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_es.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_es.properties
@@ -469,7 +469,7 @@ probe.src.deploy.file.notExists=El contexto {0} no existe
 probe.src.deploy.file.failure=Se produjo un error reportado por Tomcat durante la copia de fichero: \u00ab{0}\u00bb. Sin embargo, esto no significa que su aplicaci\u00f3n no funcione. Compruebe el estado en la lista de aplicaciones
 probe.src.deploy.file.notPath=La ruta destino seleccionada no existe
 probe.src.deploy.file.pathNotValid=La ruta de destino no es válida
-probe.src.reset.datasource.c3p0=Este fuente de datos no puede ser reinicializada
+probe.src.reset.datasource=Este fuente de datos no puede ser reinicializada
 probe.src.reset.datasource.notfound=El recurso {0} no existe
 
 probe.jsp.title.wrapper=Servicio wrapper java

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_fr.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_fr.properties
@@ -469,7 +469,7 @@ probe.src.deploy.war.uploadfailure=Probl\u00e8me pendant le transfert de: {0}
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=Cette source de donn\u00e9es ne peut \u00eatre r\u00e9initialis\u00e9e
+probe.src.reset.datasource=Cette source de donn\u00e9es ne peut \u00eatre r\u00e9initialis\u00e9e
 probe.src.reset.datasource.notfound=La ressource {0} n''existe pas
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_it.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_it.properties
@@ -469,7 +469,7 @@ probe.src.deploy.war.uploadfailure=Si \u00e9 verificato un problema caricando il
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=Qusto datasource non pu\u00f2 essere resettato
+probe.src.reset.datasource=Qusto datasource non pu\u00f2 essere resettato
 probe.src.reset.datasource.notfound=La risorsa {0} non esiste
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_ja.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_ja.properties
@@ -469,7 +469,7 @@ probe.src.deploy.war.uploadfailure=\u30d5\u30a1\u30a4\u30eb\u306e\u30a2\u30c3\u3
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=\u3054\u3081\u3093\u306a\u3055\u3044\u3001C3P0\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u306e\u307f\u30ea\u30bb\u30c3\u30c8\u53ef\u80fd\u3067\u3059\u3002
+probe.src.reset.datasource=\u3054\u3081\u3093\u306a\u3055\u3044\u3001C3P0\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u306e\u307f\u30ea\u30bb\u30c3\u30c8\u53ef\u80fd\u3067\u3059\u3002
 probe.src.reset.datasource.notfound=\u30ea\u30bd\u30fc\u30b9 {0} \u306f\u5b58\u5728\u3057\u307e\u305b\u3093\u3002
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_ko.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_ko.properties
@@ -469,7 +469,7 @@ probe.jsp.resources.empty=\uc5b4\ud50c\ub9ac\ucf00\uc774\uc158\uc5d0 \uc815\uc75
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-#probe.src.reset.datasource.c3p0=This datasource cannot be reset
+#probe.src.reset.datasource=This datasource cannot be reset
 #probe.src.reset.datasource.notfound=Resource {0} does not exist
 
 #probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_pt_BR.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_pt_BR.properties
@@ -469,7 +469,7 @@ probe.src.deploy.war.uploadfailure=Houve um erro durante o upload do arquivo: {0
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=Este datasource n\u00e3o pode ser resetado
+probe.src.reset.datasource=Este datasource n\u00e3o pode ser resetado
 probe.src.reset.datasource.notfound=Recurso {0} n\u00e3o existe
 
 probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_ru.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_ru.properties
@@ -469,7 +469,7 @@ probe.src.deploy.war.uploadfailure=\u041d\u0435 \u043f\u043e\u043b\u0443\u0447\u
 #probe.src.deploy.file.failure=There was an error thrown by Tomcat during the file copy: "{0}". This however may not mean that you application failed. Please check the status in the application list
 #probe.src.deploy.file.notPath=The selected destination path not exists
 #probe.src.deploy.file.pathNotValid=The selected destination path is not valid
-probe.src.reset.datasource.c3p0=\u042d\u0442\u043e\u0442 \u0434\u0430\u043d\u0430\u0441\u043e\u0443\u0440\u0441 \u043d\u0435 \u043c\u043e\u0436\u0435\u0442 \u0431\u044b\u0442\u044c \u0441\u0431\u0440\u043e\u0448\u0435\u043d
+probe.src.reset.datasource=\u042d\u0442\u043e\u0442 \u0434\u0430\u043d\u0430\u0441\u043e\u0443\u0440\u0441 \u043d\u0435 \u043c\u043e\u0436\u0435\u0442 \u0431\u044b\u0442\u044c \u0441\u0431\u0440\u043e\u0448\u0435\u043d
 probe.src.reset.datasource.notfound=\u0420\u0435\u0441\u0443\u0440\u0441 {0} \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d
 
 #probe.jsp.title.wrapper=Java Service Wrapper

--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_zh_CN.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_zh_CN.properties
@@ -469,7 +469,7 @@ probe.src.deploy.file.notExists={0} \u4E0D\u5B58\u5728
 probe.src.deploy.file.failure=\u590D\u5236\u6587\u4EF6\u8FC7\u7A0B\u4E2DTOMCAT\u629B\u51FA\u5F02\u5E38\: "{0}". \u8BF7\u68C0\u67E5\u5E94\u7528\u7A0B\u5E8F\u5217\u8868
 probe.src.deploy.file.notPath=\u76EE\u6807\u8DEF\u5F84\u4E0D\u5B58\u5728
 probe.src.deploy.file.pathNotValid=\u76EE\u6807\u8DEF\u5F84\u65E0\u6548
-probe.src.reset.datasource.c3p0=\u8FD9\u4E2A\u6570\u636E\u6E90\u4E0D\u80FD\u88AB\u91CD\u7F6E
+probe.src.reset.datasource=\u8FD9\u4E2A\u6570\u636E\u6E90\u4E0D\u80FD\u88AB\u91CD\u7F6E
 probe.src.reset.datasource.notfound=\u8D44\u6E90 {0} \u4E0D\u5B58\u5728
 
 probe.jsp.title.wrapper=Java Service Wrapper (Java \u670D\u52A1\u5305\u88C5\u5668)


### PR DESCRIPTION
its only rational reason to say c3p0 has to do with that one being only one setup to reset.  However, that is irrelevant in all regards because the message doesn't even talk about the specific datasource.