### PR TITLE
[ojdbc] Port code back from psi-probe at commit 40b76f7306cbb691560b1…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,10 @@
         <logback.version>1.3.7</logback.version>
         <mail.version>1.6.7</mail.version>
         <mchange.version>0.2.20</mchange.version>
+        <ojdbc.version>19.18.0.0</ojdbc.version>
         <oshi.version>6.4.2</oshi.version>
         <openejb.version>8.0.15</openejb.version>
         <persistence.version>2.2.3</persistence.version>
-        <probe-ojdbc.version>3.1.9</probe-ojdbc.version>
         <quartz.version>2.3.2</quartz.version>
         <servlet-api.version>4.0.4</servlet-api.version>
         <sitemesh.version>2.5.1</sitemesh.version>
@@ -203,6 +203,7 @@
         <text.version>1.10.0</text.version>
         <transaction-api.version>1.3.3</transaction-api.version>
         <tomcat.version>9.0.75</tomcat.version>
+        <ucp.version>19.18.0.0</ucp.version>
         <wrapper.version>3.2.3</wrapper.version>
         <xstream.version>1.4.20</xstream.version>
         <vibur-dbcp.version>25.0</vibur-dbcp.version>
@@ -372,6 +373,16 @@
                 <groupId>com.mchange</groupId>
                 <artifactId>mchange-commons-java</artifactId>
                 <version>${mchange.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ucp</artifactId>
+                <version>${ucp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc8</artifactId>
+                <version>${ojdbc.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/psi-probe-core/pom.xml
+++ b/psi-probe-core/pom.xml
@@ -34,12 +34,6 @@
     </scm>
 
     <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>psi-probe-ojdbc</artifactId>
-            <version>${probe-ojdbc.version}</version>
-        </dependency>
-
         <!-- tomcat libs start -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
@@ -88,6 +82,16 @@
         <dependency>
             <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ucp</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/psi-probe-core/src/main/java/psiprobe/UtilsBase.java
+++ b/psi-probe-core/src/main/java/psiprobe/UtilsBase.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe;
+
+import java.util.Scanner;
+
+/**
+ * Misc. static helper methods.
+ */
+public class UtilsBase {
+
+  /**
+   * Prevent Instantiation.
+   */
+  private UtilsBase() {
+    // Prevent Instantiation
+  }
+
+  /**
+   * Calc pool usage score.
+   *
+   * @param max the max
+   * @param value the value
+   * @return the int
+   */
+  public static int calcPoolUsageScore(int max, int value) {
+    return max > 0 ? Math.max(0, value) * 100 / max : 0;
+  }
+
+  /**
+   * To int.
+   *
+   * @param num the num
+   * @param defaultValue the default value
+   * @return the int
+   */
+  public static int toInt(String num, int defaultValue) {
+    if (num != null && !num.contains(" ")) {
+      try (Scanner scanner = new Scanner(num)) {
+        if (scanner.hasNextInt()) {
+          return Integer.parseInt(num);
+        }
+      }
+    }
+    return defaultValue;
+  }
+
+}

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import psiprobe.model.DataSourceInfo;
+
+/**
+ * Part of datasource type abstraction layer. Allows to extent Probe functionality to any kind of
+ * datasources.
+ */
+public interface DatasourceAccessor {
+
+  /**
+   * Gets the info.
+   *
+   * @param resource the resource
+   * @return the info
+   * @throws Exception the exception
+   */
+  DataSourceInfo getInfo(Object resource) throws Exception;
+
+  /**
+   * Reset.
+   *
+   * @param resource the resource
+   * @return true, if successful
+   * @throws Exception the exception
+   */
+  boolean reset(Object resource) throws Exception;
+
+  /**
+   * Can map.
+   *
+   * @param resource the resource
+   * @return true, if successful
+   */
+  boolean canMap(Object resource);
+}

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import java.util.Properties;
+
+import psiprobe.UtilsBase;
+import psiprobe.model.DataSourceInfo;
+
+import oracle.jdbc.pool.OracleConnectionCacheManager;
+import oracle.jdbc.pool.OracleDataSource;
+
+/**
+ * Accesses oracle.jdbc.pool.OracleDataSource.
+ *
+ * <p>
+ * Oracle connection pool is quite different from any other available for Tomcat. Datasources are
+ * run by static OracleConnectionCacheManager, whereby application context scope datasource would
+ * have a named entry in OracleConnectionCacheManager.
+ * </p>
+ *
+ * <p>
+ * Datasources do not have information about pool as such, therefore this accessor has to do quite
+ * tedious job of verifying whether the datasource has a record in the cache manager or not. The
+ * pool information is subsequently retrieved from the relevant cache manager entry.
+ * </p>
+ */
+public class OracleDatasourceAccessor implements DatasourceAccessor {
+
+  @Override
+  public DataSourceInfo getInfo(Object resource) throws Exception {
+    DataSourceInfo dataSourceInfo = null;
+
+    if (canMap(resource)) {
+      OracleDataSource source = (OracleDataSource) resource;
+      OracleConnectionCacheManager occm =
+          OracleConnectionCacheManager.getConnectionCacheManagerInstance();
+      Properties cacheProperties = source.getConnectionCacheProperties();
+      String cacheName = source.getConnectionCacheName();
+      cacheName = cacheName != null && occm.existsCache(cacheName) ? cacheName : null;
+
+      if (cacheProperties != null) {
+
+        dataSourceInfo = new DataSourceInfo();
+        if (cacheName != null) {
+          dataSourceInfo.setBusyConnections(occm.getNumberOfActiveConnections(cacheName));
+          dataSourceInfo.setEstablishedConnections(occm.getNumberOfAvailableConnections(cacheName)
+              + dataSourceInfo.getBusyConnections());
+        } else {
+          dataSourceInfo.setBusyConnections(0);
+          dataSourceInfo.setEstablishedConnections(0);
+        }
+
+        dataSourceInfo
+            .setMaxConnections(UtilsBase.toInt(cacheProperties.getProperty("MaxLimit"), -1));
+        dataSourceInfo.setJdbcUrl(source.getURL());
+        dataSourceInfo.setUsername(source.getUser());
+        dataSourceInfo.setResettable(true);
+        dataSourceInfo.setType("oracle-jdbc");
+      }
+    }
+    return dataSourceInfo;
+  }
+
+  @Override
+  public boolean reset(Object resource) throws Exception {
+    if (canMap(resource)) {
+      ((OracleDataSource) resource).close();
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean canMap(Object resource) {
+    return "oracle.jdbc.pool.OracleDataSource".equals(resource.getClass().getName())
+        && resource instanceof OracleDataSource;
+  }
+}

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import psiprobe.model.DataSourceInfo;
+
+import oracle.ucp.jdbc.JDBCConnectionPoolStatistics;
+import oracle.ucp.jdbc.PoolDataSource;
+
+/**
+ * Accesses an Oracle Universal Connection Pool (UCP) resource.
+ */
+public class OracleUcpDatasourceAccessor implements DatasourceAccessor {
+
+  @Override
+  public DataSourceInfo getInfo(Object resource) throws Exception {
+    DataSourceInfo dataSourceInfo = null;
+    if (canMap(resource)) {
+      PoolDataSource source = (PoolDataSource) resource;
+      JDBCConnectionPoolStatistics stats = source.getStatistics();
+
+      dataSourceInfo = new DataSourceInfo();
+      /*
+       * If the pool starts with 0 instances, the JDBCConnectionPoolStatistics will be null. The
+       * JDBCConnectionPoolStatistics only initializes when there is at least one connection
+       * instance created.
+       */
+      if (stats != null) {
+        dataSourceInfo.setBusyConnections(stats.getBorrowedConnectionsCount());
+        dataSourceInfo.setEstablishedConnections(stats.getTotalConnectionsCount());
+      } else {
+        dataSourceInfo.setBusyConnections(0);
+        dataSourceInfo.setEstablishedConnections(0);
+      }
+      dataSourceInfo.setMaxConnections(source.getMaxPoolSize());
+      dataSourceInfo.setJdbcUrl(source.getURL());
+      dataSourceInfo.setUsername(source.getUser());
+      dataSourceInfo.setResettable(false);
+      dataSourceInfo.setType("oracle-ucp");
+    }
+    return dataSourceInfo;
+  }
+
+  @Override
+  public boolean reset(Object resource) throws Exception {
+    return false;
+  }
+
+  @Override
+  public boolean canMap(Object resource) {
+    return ("oracle.ucp.jdbc.PoolDataSourceImpl".equals(resource.getClass().getName())
+        || "oracle.ucp.jdbc.PoolXADataSourceImpl".equals(resource.getClass().getName()))
+        && resource instanceof PoolDataSource;
+  }
+
+}

--- a/psi-probe-core/src/main/java/psiprobe/model/DataSourceInfo.java
+++ b/psi-probe-core/src/main/java/psiprobe/model/DataSourceInfo.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.model;
+
+import psiprobe.UtilsBase;
+
+/**
+ * POJO representing a datasource.
+ */
+public class DataSourceInfo {
+
+  /** The jdbc url. */
+  private String jdbcUrl;
+
+  /** The busy connections. */
+  private int busyConnections;
+
+  /** The established connections. */
+  private int establishedConnections;
+
+  /** The max connections. */
+  private int maxConnections;
+
+  /** The resettable. */
+  private boolean resettable;
+
+  /** The username. */
+  private String username;
+
+  /** The type. */
+  private String type;
+
+  /**
+   * Gets the jdbc url.
+   *
+   * @return the jdbc url
+   */
+  public String getJdbcUrl() {
+    return jdbcUrl;
+  }
+
+  /**
+   * Sets the jdbc url.
+   *
+   * @param jdbcUrl the new jdbc url
+   */
+  public void setJdbcUrl(String jdbcUrl) {
+    this.jdbcUrl = jdbcUrl;
+  }
+
+  /**
+   * Gets the busy connections.
+   *
+   * @return the busy connections
+   */
+  public int getBusyConnections() {
+    return busyConnections;
+  }
+
+  /**
+   * Sets the busy connections.
+   *
+   * @param busyConnections the new busy connections
+   */
+  public void setBusyConnections(int busyConnections) {
+    this.busyConnections = busyConnections;
+  }
+
+  /**
+   * Gets the established connections.
+   *
+   * @return the established connections
+   */
+  public int getEstablishedConnections() {
+    return establishedConnections;
+  }
+
+  /**
+   * Sets the established connections.
+   *
+   * @param establishedConnections the new established connections
+   */
+  public void setEstablishedConnections(int establishedConnections) {
+    this.establishedConnections = establishedConnections;
+  }
+
+  /**
+   * Gets the max connections.
+   *
+   * @return the max connections
+   */
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+
+  /**
+   * Sets the max connections.
+   *
+   * @param maxConnections the new max connections
+   */
+  public void setMaxConnections(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  /**
+   * Checks if is resettable.
+   *
+   * @return true, if is resettable
+   */
+  public boolean isResettable() {
+    return resettable;
+  }
+
+  /**
+   * Sets the resettable.
+   *
+   * @param resettable the new resettable
+   */
+  public void setResettable(boolean resettable) {
+    this.resettable = resettable;
+  }
+
+  /**
+   * Gets the username.
+   *
+   * @return the username
+   */
+  public String getUsername() {
+    return username;
+  }
+
+  /**
+   * Sets the username.
+   *
+   * @param username the new username
+   */
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Sets the type.
+   *
+   * @param type the new type
+   */
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  /**
+   * Gets the busy score.
+   *
+   * @return the busy score
+   */
+  public int getBusyScore() {
+    return UtilsBase.calcPoolUsageScore(getMaxConnections(), getBusyConnections());
+  }
+
+  /**
+   * Gets the established score.
+   *
+   * @return the established score
+   */
+  public int getEstablishedScore() {
+    return UtilsBase.calcPoolUsageScore(getMaxConnections(), getEstablishedConnections());
+  }
+
+}

--- a/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe;
+
+import com.codebox.bean.JavaBeanTester;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Class UtilsTest.
+ */
+public class UtilsBaseTest {
+
+  /**
+   * Calc pool usage score test.
+   */
+  @Test
+  public void calcPoolUsageScoreTest() {
+    Assertions.assertEquals(100, UtilsBase.calcPoolUsageScore(5, 5));
+    Assertions.assertEquals(0, UtilsBase.calcPoolUsageScore(0, 5));
+  }
+
+  /**
+   * To int test.
+   */
+  @Test
+  public void toIntTest() {
+    Assertions.assertEquals(5, UtilsBase.toInt("garbage", 5));
+    Assertions.assertEquals(3, UtilsBase.toInt("3", 5));
+    Assertions.assertEquals(5, UtilsBase.toInt("3 3", 5));
+    Assertions.assertEquals(5, UtilsBase.toInt((String) null, 5));
+  }
+
+  /**
+   * JavabeanTester Private Constructor.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(UtilsBase.class).testPrivateConstructor();
+  }
+
+}

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import mockit.Expectations;
+import mockit.Mocked;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import oracle.jdbc.pool.OracleDataSource;
+
+/**
+ * The Class OracleDatasourceAccessorTest.
+ */
+public class OracleDatasourceAccessorTest {
+
+  /** The accessor. */
+  OracleDatasourceAccessor accessor;
+
+  /** The source. */
+  @Mocked
+  OracleDataSource source;
+
+  /** The bad source. */
+  ComboPooledDataSource badSource;
+
+  /**
+   * Before.
+   *
+   * @throws SQLException the SQL exception
+   */
+  @BeforeEach
+  public void before() throws SQLException {
+    accessor = new OracleDatasourceAccessor();
+    badSource = new ComboPooledDataSource();
+  }
+
+  /**
+   * Can map test.
+   */
+  @Test
+  public void canMapTest() {
+    Assertions.assertTrue(accessor.canMap(source));
+  }
+
+  /**
+   * Cannot map test.
+   */
+  @Test
+  public void cannotMapTest() {
+    Assertions.assertFalse(accessor.canMap(badSource));
+  }
+
+  /**
+   * Gets the info test.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void getInfoTest() throws Exception {
+    new Expectations() {
+      {
+        source.getConnectionCacheProperties();
+        result = new Properties();
+      }
+    };
+    accessor.getInfo(source);
+  }
+
+}

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.beans.accessors;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+import oracle.ucp.jdbc.PoolXADataSourceImpl;
+
+/**
+ * The Class OracleUcpDatasourceAccessorTest.
+ */
+public class OracleUcpDatasourceAccessorTest {
+
+  /** The accessor. */
+  OracleUcpDatasourceAccessor accessor;
+
+  /** The source. */
+  PoolDataSourceImpl source;
+
+  PoolXADataSourceImpl xaSource;
+
+  /** The bad source. */
+  ComboPooledDataSource badSource;
+
+  /**
+   * Before.
+   */
+  @BeforeEach
+  public void before() {
+    accessor = new OracleUcpDatasourceAccessor();
+    source = new PoolDataSourceImpl();
+    xaSource = new PoolXADataSourceImpl();
+    badSource = new ComboPooledDataSource();
+  }
+
+  /**
+   * Can map test.
+   */
+  @Test
+  public void canMapTest() {
+    Assertions.assertTrue(accessor.canMap(source));
+  }
+
+  /**
+   * Can map XA test.
+   */
+  @Test
+  public void canMapXATest() {
+    Assertions.assertTrue(accessor.canMap(xaSource));
+  }
+
+  /**
+   * Cannot map test.
+   */
+  @Test
+  public void cannotMapTest() {
+    Assertions.assertFalse(accessor.canMap(badSource));
+  }
+
+  /**
+   * Gets the info test.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void getInfoTest() throws Exception {
+    accessor.getInfo(source);
+  }
+
+}

--- a/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe.model;
+
+import com.codebox.bean.JavaBeanTester;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Class DataSourceInfoTest.
+ */
+public class DataSourceInfoTest {
+
+  /**
+   * Javabean tester.
+   */
+  @Test
+  public void javabeanTester() {
+    JavaBeanTester.builder(DataSourceInfo.class).loadData().test();
+  }
+
+  /**
+   * Test get busy score.
+   */
+  @Test
+  public void busyScore() {
+    final DataSourceInfo dataSourceInfo = new DataSourceInfo();
+    dataSourceInfo.setBusyConnections(1);
+    dataSourceInfo.setMaxConnections(5);
+    Assertions.assertEquals(20, dataSourceInfo.getBusyScore());
+  }
+
+  /**
+   * Test get established score.
+   */
+  @Test
+  public void establishedScore() {
+    final DataSourceInfo dataSourceInfo = new DataSourceInfo();
+    dataSourceInfo.setEstablishedConnections(1);
+    dataSourceInfo.setMaxConnections(5);
+    Assertions.assertEquals(20, dataSourceInfo.getEstablishedScore());
+  }
+
+}

--- a/psi-probe-web/pom.xml
+++ b/psi-probe-web/pom.xml
@@ -49,11 +49,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>psi-probe-ojdbc</artifactId>
-            <version>${probe-ojdbc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>psi-probe-tomcat85</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
…093fb18a4f7fbfe39f1

was separated originally due to special concerns of working with oracle drivers.  They opened sourced this now many years back so the overhead of keeping it separate didn't make much sense especially when the interfaces used in psi probe had to live over there.  The old repo is now archived.