### PR TITLE
[datasources] Use SQLException instead of Exception

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/C3P0DatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/C3P0DatasourceAccessor.java
@@ -12,6 +12,8 @@ package psiprobe.beans.accessors;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
+import java.sql.SQLException;
+
 import psiprobe.model.DataSourceInfo;
 
 /**
@@ -20,7 +22,7 @@ import psiprobe.model.DataSourceInfo;
 public class C3P0DatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) throws SQLException {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       ComboPooledDataSource source = (ComboPooledDataSource) resource;
@@ -38,7 +40,7 @@ public class C3P0DatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     if (canMap(resource)) {
       ((ComboPooledDataSource) resource).hardReset();
       return true;

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/DatasourceAccessor.java
@@ -10,6 +10,8 @@
  */
 package psiprobe.beans.accessors;
 
+import java.sql.SQLException;
+
 import psiprobe.model.DataSourceInfo;
 
 /**
@@ -23,18 +25,18 @@ public interface DatasourceAccessor {
    *
    * @param resource the resource
    * @return the info
-   * @throws Exception the exception
+   * @throws SQLException the sql exception
    */
-  DataSourceInfo getInfo(Object resource) throws Exception;
+  DataSourceInfo getInfo(Object resource) throws SQLException;
 
   /**
    * Reset.
    *
    * @param resource the resource
    * @return true, if successful
-   * @throws Exception the exception
+   * @throws SQLException the sql exception
    */
-  boolean reset(Object resource) throws Exception;
+  boolean reset(Object resource) throws SQLException;
 
   /**
    * Can map.

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class Dbcp2DatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OpenEjbBasicDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OpenEjbBasicDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class OpenEjbBasicDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class OpenEjbBasicDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessor.java
@@ -22,7 +22,7 @@ import psiprobe.model.DataSourceInfo;
 public class OpenEjbManagedDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       PoolConfiguration conf = (PoolConfiguration) unwrap(resource);
@@ -41,7 +41,7 @@ public class OpenEjbManagedDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
@@ -10,6 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 import psiprobe.UtilsBase;
@@ -36,7 +37,7 @@ import oracle.jdbc.pool.OracleDataSource;
 public class OracleDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) throws SQLException {
     DataSourceInfo dataSourceInfo = null;
 
     if (canMap(resource)) {
@@ -71,7 +72,7 @@ public class OracleDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) throws SQLException {
     if (canMap(resource)) {
       ((OracleDataSource) resource).close();
       return true;

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessor.java
@@ -21,7 +21,7 @@ import oracle.ucp.jdbc.PoolDataSource;
 public class OracleUcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       PoolDataSource source = (PoolDataSource) resource;
@@ -50,7 +50,7 @@ public class OracleUcpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/TomEeJdbcPoolDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/TomEeJdbcPoolDatasourceAccessor.java
@@ -21,7 +21,7 @@ import psiprobe.model.DataSourceInfo;
 public class TomEeJdbcPoolDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       DataSource source = (DataSource) resource;
@@ -38,7 +38,7 @@ public class TomEeJdbcPoolDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       DataSource source = (DataSource) resource;
@@ -37,7 +37,7 @@ public class TomcatJdbcPoolDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/ViburCpDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/ViburCpDatasourceAccessor.java
@@ -11,9 +11,11 @@
 package psiprobe.beans.accessors;
 
 import java.lang.management.ManagementFactory;
+import java.sql.SQLException;
 
 import javax.management.JMX;
 import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import org.vibur.dbcp.ViburDBCPDataSource;
@@ -27,13 +29,18 @@ import psiprobe.model.DataSourceInfo;
 public class ViburCpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(final Object resource) throws Exception {
+  public DataSourceInfo getInfo(final Object resource) throws SQLException {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       ViburDBCPDataSource source = (ViburDBCPDataSource) resource;
 
       MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
-      ObjectName poolName = new ObjectName(source.getJmxName());
+      ObjectName poolName;
+      try {
+        poolName = new ObjectName(source.getJmxName());
+      } catch (MalformedObjectNameException e) {
+        throw new SQLException("MalformedObjectNameException for Vibur", e);
+      }
       ViburMonitoringMBean poolProxy =
           JMX.newMXBeanProxy(mbeanServer, poolName, ViburMonitoringMBean.class);
 
@@ -51,7 +58,7 @@ public class ViburCpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(final Object resource) throws Exception {
+  public boolean reset(final Object resource) {
     return false;
   }
 

--- a/psi-probe-tomcat10/src/main/java/psiprobe/beans/accessors/Tomcat10DbcpDatasourceAccessor.java
+++ b/psi-probe-tomcat10/src/main/java/psiprobe/beans/accessors/Tomcat10DbcpDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class Tomcat10DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class Tomcat10DbcpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-tomcat11/src/main/java/psiprobe/beans/accessors/Tomcat11DbcpDatasourceAccessor.java
+++ b/psi-probe-tomcat11/src/main/java/psiprobe/beans/accessors/Tomcat11DbcpDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class Tomcat11DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class Tomcat11DbcpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-tomcat85/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
+++ b/psi-probe-tomcat85/src/main/java/psiprobe/beans/accessors/Tomcat85DbcpDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class Tomcat85DbcpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 

--- a/psi-probe-tomcat9/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
+++ b/psi-probe-tomcat9/src/main/java/psiprobe/beans/accessors/Tomcat9DbcpDatasourceAccessor.java
@@ -20,7 +20,7 @@ import psiprobe.model.DataSourceInfo;
 public class Tomcat9DbcpDatasourceAccessor implements DatasourceAccessor {
 
   @Override
-  public DataSourceInfo getInfo(Object resource) throws Exception {
+  public DataSourceInfo getInfo(Object resource) {
     DataSourceInfo dataSourceInfo = null;
     if (canMap(resource)) {
       BasicDataSource source = (BasicDataSource) resource;
@@ -37,7 +37,7 @@ public class Tomcat9DbcpDatasourceAccessor implements DatasourceAccessor {
   }
 
   @Override
-  public boolean reset(Object resource) throws Exception {
+  public boolean reset(Object resource) {
     return false;
   }
 


### PR DESCRIPTION
- for few malformed exceptions, rethrow as SQL Exceptions with context they are malformed for the specific connection pooling.  Remainder were either never thrown or where otherwise SQLExceptions.