### PR TITLE
[fix] For messages_es convert it from ansi encoding to utf-8 as expected

### DIFF
--- a/psi-probe-web/src/main/webapp/WEB-INF/messages_es.properties
+++ b/psi-probe-web/src/main/webapp/WEB-INF/messages_es.properties
@@ -468,7 +468,7 @@ probe.src.deploy.file.notFile.failure=Copia fallida. No se ha seleccionado fiche
 probe.src.deploy.file.notExists=El contexto {0} no existe
 probe.src.deploy.file.failure=Se produjo un error reportado por Tomcat durante la copia de fichero: \u00ab{0}\u00bb. Sin embargo, esto no significa que su aplicaci\u00f3n no funcione. Compruebe el estado en la lista de aplicaciones
 probe.src.deploy.file.notPath=La ruta destino seleccionada no existe
-probe.src.deploy.file.pathNotValid=La ruta de destino no es v·lida
+probe.src.deploy.file.pathNotValid=La ruta de destino no es v√°lida
 probe.src.reset.datasource=Este fuente de datos no puede ser reinicializada
 probe.src.reset.datasource.notfound=El recurso {0} no existe
 


### PR DESCRIPTION
with war plugin 3.4.0 this was breaking, turned out the encoding was incorrect and running switch on it fixed the issue.