### PR TITLE
junit 5 test cleanup and move ucp to 21.10.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <text.version>1.10.0</text.version>
         <tomcat.version>9.0.76</tomcat.version>
         <transaction-api.version>1.3.3</transaction-api.version>
-        <ucp.version>19.19.0.0</ucp.version>
+        <ucp.version>21.10.0.0</ucp.version>
         <wrapper.version>3.2.3</wrapper.version>
         <xstream.version>1.4.20</xstream.version>
         <vibur-dbcp.version>25.0</vibur-dbcp.version>

--- a/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
@@ -24,7 +24,7 @@ public class UtilsBaseTest {
    * Calc pool usage score test.
    */
   @Test
-  public void calcPoolUsageScoreTest() {
+  void calcPoolUsageScoreTest() {
     Assertions.assertEquals(100, UtilsBase.calcPoolUsageScore(5, 5));
     Assertions.assertEquals(0, UtilsBase.calcPoolUsageScore(0, 5));
   }
@@ -33,7 +33,7 @@ public class UtilsBaseTest {
    * To int test.
    */
   @Test
-  public void toIntTest() {
+  void toIntTest() {
     Assertions.assertEquals(5, UtilsBase.toInt("garbage", 5));
     Assertions.assertEquals(3, UtilsBase.toInt("3", 5));
     Assertions.assertEquals(5, UtilsBase.toInt("3 3", 5));
@@ -44,7 +44,7 @@ public class UtilsBaseTest {
    * JavabeanTester Private Constructor.
    */
   @Test
-  public void javabeanTester() {
+  void javabeanTester() {
     JavaBeanTester.builder(UtilsBase.class).testPrivateConstructor();
   }
 

--- a/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/UtilsBaseTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 /**
  * The Class UtilsTest.
  */
-public class UtilsBaseTest {
+class UtilsBaseTest {
 
   /**
    * Calc pool usage score test.

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -45,7 +45,7 @@ public class OracleDatasourceAccessorTest {
    * @throws SQLException the SQL exception
    */
   @BeforeEach
-  public void before() throws SQLException {
+  void before() throws SQLException {
     accessor = new OracleDatasourceAccessor();
     badSource = new ComboPooledDataSource();
   }
@@ -54,7 +54,7 @@ public class OracleDatasourceAccessorTest {
    * Can map test.
    */
   @Test
-  public void canMapTest() {
+  void canMapTest() {
     Assertions.assertTrue(accessor.canMap(source));
   }
 
@@ -62,7 +62,7 @@ public class OracleDatasourceAccessorTest {
    * Cannot map test.
    */
   @Test
-  public void cannotMapTest() {
+  void cannotMapTest() {
     Assertions.assertFalse(accessor.canMap(badSource));
   }
 
@@ -72,7 +72,7 @@ public class OracleDatasourceAccessorTest {
    * @throws Exception the exception
    */
   @Test
-  public void getInfoTest() throws Exception {
+  void getInfoTest() throws Exception {
     new Expectations() {
       {
         source.getConnectionCacheProperties();

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -27,7 +27,7 @@ import oracle.jdbc.pool.OracleDataSource;
 /**
  * The Class OracleDatasourceAccessorTest.
  */
-public class OracleDatasourceAccessorTest {
+class OracleDatasourceAccessorTest {
 
   /** The accessor. */
   OracleDatasourceAccessor accessor;

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -39,7 +39,7 @@ public class OracleUcpDatasourceAccessorTest {
    * Before.
    */
   @BeforeEach
-  public void before() {
+  void before() {
     accessor = new OracleUcpDatasourceAccessor();
     source = new PoolDataSourceImpl();
     xaSource = new PoolXADataSourceImpl();
@@ -50,7 +50,7 @@ public class OracleUcpDatasourceAccessorTest {
    * Can map test.
    */
   @Test
-  public void canMapTest() {
+  void canMapTest() {
     Assertions.assertTrue(accessor.canMap(source));
   }
 
@@ -58,7 +58,7 @@ public class OracleUcpDatasourceAccessorTest {
    * Can map XA test.
    */
   @Test
-  public void canMapXATest() {
+  void canMapXATest() {
     Assertions.assertTrue(accessor.canMap(xaSource));
   }
 
@@ -66,7 +66,7 @@ public class OracleUcpDatasourceAccessorTest {
    * Cannot map test.
    */
   @Test
-  public void cannotMapTest() {
+  void cannotMapTest() {
     Assertions.assertFalse(accessor.canMap(badSource));
   }
 
@@ -76,7 +76,7 @@ public class OracleUcpDatasourceAccessorTest {
    * @throws Exception the exception
    */
   @Test
-  public void getInfoTest() throws Exception {
+  void getInfoTest() throws Exception {
     accessor.getInfo(source);
   }
 

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -22,7 +22,7 @@ import oracle.ucp.jdbc.PoolXADataSourceImpl;
 /**
  * The Class OracleUcpDatasourceAccessorTest.
  */
-public class OracleUcpDatasourceAccessorTest {
+class OracleUcpDatasourceAccessorTest {
 
   /** The accessor. */
   OracleUcpDatasourceAccessor accessor;

--- a/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
@@ -24,7 +24,7 @@ public class DataSourceInfoTest {
    * Javabean tester.
    */
   @Test
-  public void javabeanTester() {
+  void javabeanTester() {
     JavaBeanTester.builder(DataSourceInfo.class).loadData().test();
   }
 
@@ -32,7 +32,7 @@ public class DataSourceInfoTest {
    * Test get busy score.
    */
   @Test
-  public void busyScore() {
+  void busyScore() {
     final DataSourceInfo dataSourceInfo = new DataSourceInfo();
     dataSourceInfo.setBusyConnections(1);
     dataSourceInfo.setMaxConnections(5);
@@ -43,7 +43,7 @@ public class DataSourceInfoTest {
    * Test get established score.
    */
   @Test
-  public void establishedScore() {
+  void establishedScore() {
     final DataSourceInfo dataSourceInfo = new DataSourceInfo();
     dataSourceInfo.setEstablishedConnections(1);
     dataSourceInfo.setMaxConnections(5);

--- a/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/model/DataSourceInfoTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 /**
  * The Class DataSourceInfoTest.
  */
-public class DataSourceInfoTest {
+class DataSourceInfoTest {
 
   /**
    * Javabean tester.


### PR DESCRIPTION
ojdbc logic for same is deprecated and deleted in 21c and above.  Since many still use 19c, leaving that be for now.  Both are provided and neither required to stay in sync.