### PR TITLE
Deprecate oracle pooling / Fixup deprecated spring property handling and drop system properties override mode

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/ProbeConfig.java
+++ b/psi-probe-core/src/main/java/psiprobe/ProbeConfig.java
@@ -23,11 +23,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
-import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.web.servlet.HandlerMapping;
@@ -378,10 +378,10 @@ public class ProbeConfig implements WebMvcConfigurer {
    *
    * @return the property placeholder configurer
    */
-  @Bean(name = "propertyPlaceholderConfigurer")
-  public static PropertyPlaceholderConfigurer getPropertyPlaceholderConfigurer() {
+  @Bean(name = "propertySourcesPlaceholderConfigurer")
+  public static PropertySourcesPlaceholderConfigurer getPropertyPlaceholderConfigurer() {
     logger.debug("Instantiated propertyPlaceholderConfigurer");
-    PropertyPlaceholderConfigurer configurer = new PropertyPlaceholderConfigurer();
+    PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
     configurer.setLocation(new ClassPathResource("stats.properties"));
     configurer.setNullValue("NULL");
 
@@ -389,9 +389,6 @@ public class ProbeConfig implements WebMvcConfigurer {
     properties.put("psiprobe.tools.mail.to", "NULL");
     properties.put("psiprobe.tools.mail.subjectPrefix", "[PSI Probe]");
     configurer.setProperties(properties);
-
-    configurer.setSystemPropertiesModeName("SYSTEM_PROPERTIES_MODE_OVERRIDE");
-
     return configurer;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/ProbeConfig.java
+++ b/psi-probe-core/src/main/java/psiprobe/ProbeConfig.java
@@ -379,8 +379,8 @@ public class ProbeConfig implements WebMvcConfigurer {
    * @return the property placeholder configurer
    */
   @Bean(name = "propertySourcesPlaceholderConfigurer")
-  public static PropertySourcesPlaceholderConfigurer getPropertyPlaceholderConfigurer() {
-    logger.debug("Instantiated propertyPlaceholderConfigurer");
+  public static PropertySourcesPlaceholderConfigurer getPropertySourcesPlaceholderConfigurer() {
+    logger.debug("Instantiated propertySourcesPlaceholderConfigurer");
     PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
     configurer.setLocation(new ClassPathResource("stats.properties"));
     configurer.setNullValue("NULL");

--- a/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
+++ b/psi-probe-core/src/main/java/psiprobe/beans/accessors/OracleDatasourceAccessor.java
@@ -33,7 +33,11 @@ import oracle.jdbc.pool.OracleDataSource;
  * tedious job of verifying whether the datasource has a record in the cache manager or not. The
  * pool information is subsequently retrieved from the relevant cache manager entry.
  * </p>
+ *
+ * @deprecated As of 21c, this is deleted by oracle, therefore please transition to ucp which we
+ *             support now.
  */
+@Deprecated
 public class OracleDatasourceAccessor implements DatasourceAccessor {
 
   @Override


### PR DESCRIPTION
don't see that system properties override mode was documented nor used.  marking oracle pooling as deprecated as they deleted the code involved in 21c.  At the moment, still sitting on 19c for ojdbc datasource and 21c for ucp.  Cannot move ucp forwards until we delete current usage of ojdbc and/or review further.