### PR TITLE
[tests] Stop using cp30 as a bad source / use hikari or vbur

### DIFF
--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/Dbcp2DatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.Assertions;
@@ -29,7 +29,7 @@ class Dbcp2DatasourceAccessorTest {
   BasicDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -38,7 +38,7 @@ class Dbcp2DatasourceAccessorTest {
   void before() {
     accessor = new Dbcp2DatasourceAccessor();
     source = new BasicDataSource();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/HikariCpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/HikariCpDatasourceAccessorTest.java
@@ -10,7 +10,6 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariDataSource;
 
 import mockit.Mocked;
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.vibur.dbcp.ViburDBCPDataSource;
 
 /**
  * The Class HikariCpDatasourceAccessorTest.
@@ -33,7 +33,7 @@ class HikariCpDatasourceAccessorTest {
   HikariDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  ViburDBCPDataSource badSource;
 
   /**
    * Before.
@@ -41,7 +41,7 @@ class HikariCpDatasourceAccessorTest {
   @BeforeEach
   void before() {
     accessor = new HikariCpDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new ViburDBCPDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OpenEjbBasicDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OpenEjbBasicDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import mockit.Mocked;
 import mockit.Tested;
@@ -35,7 +35,7 @@ class OpenEjbBasicDatasourceAccessorTest {
   BasicDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -43,7 +43,7 @@ class OpenEjbBasicDatasourceAccessorTest {
   @BeforeEach
   void before() {
     accessor = new OpenEjbBasicDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OpenEjbManagedDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import mockit.Mocked;
 import mockit.Tested;
@@ -35,7 +35,7 @@ class OpenEjbManagedDatasourceAccessorTest {
   ManagedDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -43,7 +43,7 @@ class OpenEjbManagedDatasourceAccessorTest {
   @BeforeEach
   void before() {
     accessor = new OpenEjbManagedDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import java.sql.SQLException;
 import java.util.Properties;
@@ -37,7 +37,7 @@ class OracleDatasourceAccessorTest {
   OracleDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -47,7 +47,7 @@ class OracleDatasourceAccessorTest {
   @BeforeEach
   void before() throws SQLException {
     accessor = new OracleDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/OracleUcpDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +33,7 @@ class OracleUcpDatasourceAccessorTest {
   PoolXADataSourceImpl xaSource;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -43,7 +43,7 @@ class OracleUcpDatasourceAccessorTest {
     accessor = new OracleUcpDatasourceAccessor();
     source = new PoolDataSourceImpl();
     xaSource = new PoolXADataSourceImpl();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/TomcatJdbcPoolDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import mockit.Mocked;
 
@@ -32,7 +32,7 @@ class TomcatJdbcPoolDatasourceAccessorTest {
   DataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -40,7 +40,7 @@ class TomcatJdbcPoolDatasourceAccessorTest {
   @BeforeEach
   void before() {
     accessor = new TomcatJdbcPoolDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**

--- a/psi-probe-core/src/test/java/psiprobe/beans/accessors/ViburCpDatasourceAccessorTest.java
+++ b/psi-probe-core/src/test/java/psiprobe/beans/accessors/ViburCpDatasourceAccessorTest.java
@@ -10,7 +10,7 @@
  */
 package psiprobe.beans.accessors;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -34,7 +34,7 @@ class ViburCpDatasourceAccessorTest {
   ViburDBCPDataSource source;
 
   /** The bad source. */
-  ComboPooledDataSource badSource;
+  HikariDataSource badSource;
 
   /**
    * Before.
@@ -42,7 +42,7 @@ class ViburCpDatasourceAccessorTest {
   @BeforeEach
   void before() {
     accessor = new ViburCpDatasourceAccessor();
-    badSource = new ComboPooledDataSource();
+    badSource = new HikariDataSource();
   }
 
   /**


### PR DESCRIPTION
This makes it easier to drop c3p0 in near future as the intent of the change.