### PR TITLE
Cleanup library api usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@
         <ojdbc.version>19.21.0.0</ojdbc.version>
         <oshi.version>6.4.7</oshi.version>
         <quartz.version>2.4.0-rc2</quartz.version>
+        <servlet-api.version>4.0.4</servlet-api.version>
         <sitemesh.version>2.5.1</sitemesh.version>
         <slf4j.version>2.0.9</slf4j.version>
         <spotbugs.version>4.8.1</spotbugs.version>
@@ -327,6 +328,11 @@
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject-api</artifactId>
                 <version>${inject.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet.jsp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,10 @@
                         <groupId>org.apache.tomee</groupId>
                         <artifactId>mbean-annotation-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.tomee</groupId>
+                        <artifactId>javaee-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,12 @@
                 <groupId>com.github.hazendaz</groupId>
                 <artifactId>displaytag</artifactId>
                 <version>${displaytag.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Logging -->
@@ -571,6 +577,12 @@
                 <groupId>com.github.hazendaz</groupId>
                 <artifactId>sitemesh</artifactId>
                 <version>${sitemesh.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,6 @@
         <ojdbc.version>19.21.0.0</ojdbc.version>
         <oshi.version>6.4.7</oshi.version>
         <quartz.version>2.4.0-rc2</quartz.version>
-        <servlet-api.version>4.0.4</servlet-api.version>
         <sitemesh.version>2.5.1</sitemesh.version>
         <slf4j.version>2.0.9</slf4j.version>
         <spotbugs.version>4.8.1</spotbugs.version>
@@ -328,11 +327,6 @@
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject-api</artifactId>
                 <version>${inject.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet.jsp</groupId>

--- a/psi-probe-core/pom.xml
+++ b/psi-probe-core/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jfree</groupId>

--- a/psi-probe-core/pom.xml
+++ b/psi-probe-core/pom.xml
@@ -70,11 +70,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
             <scope>compile</scope>

--- a/psi-probe-web/pom.xml
+++ b/psi-probe-web/pom.xml
@@ -61,6 +61,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
             <scope>provided</scope>

--- a/psi-probe-web/pom.xml
+++ b/psi-probe-web/pom.xml
@@ -61,11 +61,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
             <scope>provided</scope>

--- a/psi-probe-web/pom.xml
+++ b/psi-probe-web/pom.xml
@@ -81,20 +81,6 @@
         <dependency>
             <groupId>com.github.hazendaz</groupId>
             <artifactId>displaytag</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.web</groupId>
-                    <artifactId>javax.servlet.jsp.jstl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.servlet.jsp.jstl</groupId>
-                    <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
- Make sure jcl over slf4j is excluded from sitemesh / displaytag right up front
- Remove all exclusions from displaytag in web module
- Change transaction api to provided
- Remove servlet api from the core module as only needed in web where tomcats not shown for same
- Exclude javaee-api from openejb