### PR TITLE
[cleanup] Use enhanced for loop to handle thread enumeration process

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/Utils.java
+++ b/psi-probe-core/src/main/java/psiprobe/Utils.java
@@ -407,11 +407,11 @@ public final class Utils {
       }
 
       Thread[] threads = new Thread[masterGroup.activeCount()];
-      int numThreads = masterGroup.enumerate(threads);
+      masterGroup.enumerate(threads);
 
-      for (int i = 0; i < numThreads; i++) {
-        if (threads[i] != null && name.equals(threads[i].getName())) {
-          return threads[i];
+      for (Thread thread : threads) {
+        if (thread != null && name.equals(thread.getName())) {
+          return thread;
         }
       }
     }


### PR DESCRIPTION
The enumerate method is overloaded, it loads the array and returns count.  We don't need the count, just use the thread in enhanced array and process through it.