### PR TITLE
Certificates display changes

### DIFF
--- a/psi-probe-web/src/main/webapp/WEB-INF/jsp/certificates.jsp
+++ b/psi-probe-web/src/main/webapp/WEB-INF/jsp/certificates.jsp
@@ -35,18 +35,14 @@
                 <div class="connectorCertificates">
 
                     <c:forEach items="${connector.sslHostConfigInfos}" var="sslHostConfigInfo">
-                        <c:if test="${! empty sslHostConfigInfo.trustStoreCerts}">
-                            <c:set var="certs" value="${sslHostConfigInfo.trustStoreCerts}" scope="request" />
-                            <h4><spring:message code="probe.jsp.certificates.trustStore"/></h4>
-                            <c:import url="certificates_table.jsp" />
-                        </c:if>
+                        <c:set var="certs" value="${sslHostConfigInfo.trustStoreCerts}" scope="request" />
+                        <h4><spring:message code="probe.jsp.certificates.trustStore"/></h4>
+                        <c:import url="certificates_table.jsp" />
 
                         <c:forEach items="${sslHostConfigInfo.certificateInfos}" var="certificateInfo">
-                            <c:if test="${! empty certificateInfo.keyStoreCerts}">
-                                <c:set var="certs" value="${certificateInfo.keyStoreCerts}" scope="request" />
-                                <h4><spring:message code="probe.jsp.certificates.keyStore"/></h4>
-                                <c:import url="certificates_table.jsp" />
-                            </c:if>
+                            <c:set var="certs" value="${certificateInfo.keyStoreCerts}" scope="request" />
+                            <h4><spring:message code="probe.jsp.certificates.keyStore"/></h4>
+                            <c:import url="certificates_table.jsp" />
                         </c:forEach>
                     </c:forEach>
 

--- a/psi-probe-web/src/main/webapp/WEB-INF/jsp/certificates.jsp
+++ b/psi-probe-web/src/main/webapp/WEB-INF/jsp/certificates.jsp
@@ -35,14 +35,14 @@
                 <div class="connectorCertificates">
 
                     <c:forEach items="${connector.sslHostConfigInfos}" var="sslHostConfigInfo">
-                        <c:if test="${!sslHostConfigInfo.trustStoreCerts.isEmpty()}">
+                        <c:if test="${! empty sslHostConfigInfo.trustStoreCerts}">
                             <c:set var="certs" value="${sslHostConfigInfo.trustStoreCerts}" scope="request" />
                             <h4><spring:message code="probe.jsp.certificates.trustStore"/></h4>
                             <c:import url="certificates_table.jsp" />
                         </c:if>
 
                         <c:forEach items="${sslHostConfigInfo.certificateInfos}" var="certificateInfo">
-                            <c:if test="${!certificateInfo.keyStoreCerts.isEmpty()}">
+                            <c:if test="${! empty certificateInfo.keyStoreCerts}">
                                 <c:set var="certs" value="${certificateInfo.keyStoreCerts}" scope="request" />
                                 <h4><spring:message code="probe.jsp.certificates.keyStore"/></h4>
                                 <c:import url="certificates_table.jsp" />


### PR DESCRIPTION
Original logic to check empty from 4.0.0 release was wrong, fixed that but also removed it afterwards as it showing nothing was confusing but having it delegate to display tag to display 'Nothing found to display.' with proper headers around it looks better.