### PR TITLE
[fix] Make sure war is check to exist as it is moved and will not be …

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -198,6 +198,7 @@ public class CopySingleFileController extends AbstractTomcatContainerController 
       if (errMsg != null) {
         request.setAttribute("errorMessage", errMsg);
       }
+      // File is copied so it will exist
       Files.delete(tmpFile.toPath());
     }
     return new ModelAndView(new InternalResourceView(getViewName()));

--- a/psi-probe-core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -188,7 +188,10 @@ public class UploadWarController extends AbstractTomcatContainerController {
       if (errMsg != null) {
         request.setAttribute("errorMessage", errMsg);
       }
-      Files.delete(tmpWar.toPath());
+      // If war was not moved, delete it
+      if (tmpWar.exists()) {
+          Files.delete(tmpWar.toPath());
+      }
     }
     return new ModelAndView(new InternalResourceView(getViewName()));
   }


### PR DESCRIPTION
…when successful

add comment in copy single file controller as similar but never had the extra check as not needed since it copied rather than moved.