### PR TITLE
Remove distro management for submodules on site as it made it worse

### DIFF
--- a/psi-probe-core/pom.xml
+++ b/psi-probe-core/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <dependencies>
         <!-- tomcat libs start -->

--- a/psi-probe-rest/pom.xml
+++ b/psi-probe-rest/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/psi-probe-tomcat10/pom.xml
+++ b/psi-probe-tomcat10/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <properties>
         <tomcat.version>10.1.19</tomcat.version>

--- a/psi-probe-tomcat11/pom.xml
+++ b/psi-probe-tomcat11/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <properties>
         <tomcat.version>11.0.0-M17</tomcat.version>

--- a/psi-probe-tomcat85/pom.xml
+++ b/psi-probe-tomcat85/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <properties>
         <tomcat.version>8.5.99</tomcat.version>

--- a/psi-probe-tomcat9/pom.xml
+++ b/psi-probe-tomcat9/pom.xml
@@ -35,13 +35,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <properties>
         <tomcat.version>9.0.86</tomcat.version>

--- a/psi-probe-web/pom.xml
+++ b/psi-probe-web/pom.xml
@@ -36,13 +36,6 @@
         <tag>HEAD</tag>
         <url>https://github.com/psi-probe/psi-probe/</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>gh-pages-scm</id>
-            <name>Psi-Probe GitHub Pages</name>
-            <url>scm:git:ssh://git@github.com/psi-probe/psi-probe.git</url>
-        </site>
-    </distributionManagement>
 
     <properties>
         <!-- jspc still requires 1.8 -->


### PR DESCRIPTION
See #3131 as attempt resulted in it overwriting the site.  Further, GHA also did the same.  So reverting this so we get back to working order with GHA.