### PR TITLE
Update tomcat and rework upload logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <spring.version>5.3.34</spring.version>
         <spring-security.version>5.8.12</spring-security.version>
         <text.version>1.12.0</text.version>
-        <tomcat.version>9.0.87</tomcat.version>
+        <tomcat.version>9.0.88</tomcat.version>
         <tomee.version>8.0.16</tomee.version>
         <transaction-api.version>1.3.3</transaction-api.version>
         <ucp.version>21.13.0.0</ucp.version>

--- a/psi-probe-core/src/main/java/psiprobe/controllers/AbstractTomcatContainerController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/AbstractTomcatContainerController.java
@@ -10,8 +10,12 @@
  */
 package psiprobe.controllers;
 
-import javax.inject.Inject;
+import java.util.Locale;
 
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.tomcat.util.http.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -34,6 +38,12 @@ public abstract class AbstractTomcatContainerController extends AbstractControll
 
   /** The view name. */
   private String viewName;
+
+  /** Part of HTTP content type header. */
+  private static final String MULTIPART = "multipart/";
+
+  /** Constant for HTTP POST method. */
+  private static final String POST_METHOD = "POST";
 
   /**
    * Gets the container wrapper.
@@ -70,4 +80,24 @@ public abstract class AbstractTomcatContainerController extends AbstractControll
   public void setViewName(String viewName) {
     this.viewName = viewName;
   }
+
+  /**
+   * Utility method that determines whether the request contains multipart content. Borrowed and
+   * modified from tomcat as they removed it in 9.0.88 and 10.1.x lines.
+   *
+   * @param request The request context to be evaluated. Must be non-null.
+   *
+   * @return {@code true} if the request is multipart; {@code false} otherwise.
+   */
+  public boolean isMultipartContent(final HttpServletRequest request) {
+    if (!POST_METHOD.equalsIgnoreCase(request.getMethod())) {
+      return false;
+    }
+    final String contentType = new ServletRequestContext(request).getContentType();
+    if (contentType == null) {
+      return false;
+    }
+    return contentType.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART);
+  }
+
 }

--- a/psi-probe-core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/deploy/CopySingleFileController.java
@@ -29,8 +29,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tomcat.util.http.fileupload.FileItem;
 import org.apache.tomcat.util.http.fileupload.FileItemFactory;
+import org.apache.tomcat.util.http.fileupload.FileUpload;
 import org.apache.tomcat.util.http.fileupload.disk.DiskFileItemFactory;
-import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
 import org.apache.tomcat.util.http.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +65,7 @@ public class CopySingleFileController extends AbstractTomcatContainerController 
       HttpServletResponse response) throws Exception {
 
     // If not multi-part content, exit
-    if (!ServletFileUpload.isMultipartContent(request)) {
+    if (!this.isMultipartContent(request)) {
       return new ModelAndView(new InternalResourceView(getViewName()));
     }
 
@@ -98,7 +98,8 @@ public class CopySingleFileController extends AbstractTomcatContainerController 
     // parse multipart request and extract the file
     FileItemFactory factory =
         new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-    ServletFileUpload upload = new ServletFileUpload(factory);
+    FileUpload upload = new FileUpload();
+    upload.setFileItemFactory(factory);
     upload.setSizeMax(-1);
     upload.setHeaderEncoding(StandardCharsets.UTF_8.name());
     try {

--- a/psi-probe-core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/deploy/UploadWarController.java
@@ -24,8 +24,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tomcat.util.http.fileupload.FileItem;
 import org.apache.tomcat.util.http.fileupload.FileItemFactory;
+import org.apache.tomcat.util.http.fileupload.FileUpload;
 import org.apache.tomcat.util.http.fileupload.disk.DiskFileItemFactory;
-import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
 import org.apache.tomcat.util.http.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +63,7 @@ public class UploadWarController extends AbstractTomcatContainerController {
       HttpServletResponse response) throws Exception {
 
     // If not multi-part content, exit
-    if (!ServletFileUpload.isMultipartContent(request)) {
+    if (!this.isMultipartContent(request)) {
       return new ModelAndView(new InternalResourceView(getViewName()));
     }
 
@@ -76,7 +76,8 @@ public class UploadWarController extends AbstractTomcatContainerController {
     // parse multipart request and extract the file
     FileItemFactory factory =
         new DiskFileItemFactory(1048000, new File(System.getProperty("java.io.tmpdir")));
-    ServletFileUpload upload = new ServletFileUpload(factory);
+    FileUpload upload = new FileUpload();
+    upload.setFileItemFactory(factory);
     upload.setSizeMax(-1);
     upload.setHeaderEncoding(StandardCharsets.UTF_8.name());
     try {

--- a/psi-probe-tomcat11/pom.xml
+++ b/psi-probe-tomcat11/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <tomcat.version>11.0.0-M18</tomcat.version>
+        <tomcat.version>11.0.0-M19</tomcat.version>
 
         <!-- Java Settings -->
         <java.version>21</java.version>

--- a/psi-probe-tomcat9/pom.xml
+++ b/psi-probe-tomcat9/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <tomcat.version>9.0.87</tomcat.version>
+        <tomcat.version>9.0.88</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
It seems tomcat backported changes to tomcat 9 that breaks same issue I faced with tomcat 10.1 usage.  I have hope pulling some of their code and confirming it still uploads might make jakarta a go.  Getting this merged then will retest.  If it works out, expect to release this again on javax then follow up a quick jakarta.  My hope anyways..