### PR TITLE
[pom] Use target folder only for error prone ignore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 
         <!-- Verification Checks -->
         <error-prone.failOnViolations>-XepAllErrorsAsWarnings</error-prone.failOnViolations>
-        <error-prone.skipGeneratedCode>-XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*${project.build.directory}/generated-sources/.*</error-prone.skipGeneratedCode>
+        <error-prone.skipGeneratedCode>-XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*target/generated-sources/.*</error-prone.skipGeneratedCode>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
some cases this had issues, so just use target directly rather than trying to resolve from maven