### PR TITLE
Known changes to better support tomcat 11

### DIFF
--- a/psi-probe-core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/certificates/ListCertificatesController.java
@@ -33,7 +33,7 @@ import javax.management.ObjectName;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.ProtocolHandler;
-import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -182,8 +182,8 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
 
       ProtocolHandler protocolHandler = connector.getProtocolHandler();
 
-      if (protocolHandler instanceof AbstractHttp11JsseProtocol) {
-        AbstractHttp11JsseProtocol<?> protocol = (AbstractHttp11JsseProtocol<?>) protocolHandler;
+      if (protocolHandler instanceof AbstractHttp11Protocol) {
+        AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) protocolHandler;
         if (!protocol.getSecure()) {
           continue;
         }
@@ -234,7 +234,7 @@ public class ListCertificatesController extends AbstractTomcatContainerControlle
    * @throws IllegalAccessException the illegal access exception
    * @throws InvocationTargetException the invocation target exception
    */
-  private ConnectorInfo toConnectorInfo(AbstractHttp11JsseProtocol<?> protocol)
+  private ConnectorInfo toConnectorInfo(AbstractHttp11Protocol<?> protocol)
       throws IllegalAccessException, InvocationTargetException {
     ConnectorInfo info = new ConnectorInfo();
     info.setName(ObjectName.unquote(protocol.getName()));

--- a/psi-probe-core/src/main/java/psiprobe/controllers/certificates/SslHostConfigHelper.java
+++ b/psi-probe-core/src/main/java/psiprobe/controllers/certificates/SslHostConfigHelper.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
 
@@ -38,7 +38,7 @@ public class SslHostConfigHelper {
    * @throws IllegalAccessException the illegal access exception
    * @throws InvocationTargetException the invocation target exception
    */
-  public SslHostConfigHelper(AbstractHttp11JsseProtocol<?> protocol, ConnectorInfo info)
+  public SslHostConfigHelper(AbstractHttp11Protocol<?> protocol, ConnectorInfo info)
       throws IllegalAccessException, InvocationTargetException {
     SSLHostConfig[] sslHostConfigs = protocol.findSslHostConfigs();
     List<SslHostConfigInfo> sslHostConfigInfos = new ArrayList<>(sslHostConfigs.length);

--- a/psi-probe-core/src/main/java/psiprobe/model/Application.java
+++ b/psi-probe-core/src/main/java/psiprobe/model/Application.java
@@ -66,13 +66,13 @@ public class Application implements Serializable {
   private int servletCount;
 
   /** The request count. */
-  private int requestCount;
+  private long requestCount;
 
   /** The processing time. */
   private long processingTime;
 
   /** The error count. */
-  private int errorCount;
+  private long errorCount;
 
   /** The min time. */
   private long minTime;
@@ -367,7 +367,7 @@ public class Application implements Serializable {
    *
    * @return the request count
    */
-  public int getRequestCount() {
+  public long getRequestCount() {
     return requestCount;
   }
 
@@ -376,7 +376,7 @@ public class Application implements Serializable {
    *
    * @param requestCount the new request count
    */
-  public void setRequestCount(int requestCount) {
+  public void setRequestCount(long requestCount) {
     this.requestCount = requestCount;
   }
 
@@ -403,7 +403,7 @@ public class Application implements Serializable {
    *
    * @return the error count
    */
-  public int getErrorCount() {
+  public long getErrorCount() {
     return errorCount;
   }
 
@@ -412,7 +412,7 @@ public class Application implements Serializable {
    *
    * @param errorCount the new error count
    */
-  public void setErrorCount(int errorCount) {
+  public void setErrorCount(long errorCount) {
     this.errorCount = errorCount;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/model/ServletInfo.java
+++ b/psi-probe-core/src/main/java/psiprobe/model/ServletInfo.java
@@ -39,7 +39,7 @@ public class ServletInfo {
   private String runAs;
 
   /** The error count. */
-  private int errorCount;
+  private long errorCount;
 
   /** The load time. */
   private long loadTime;
@@ -54,7 +54,7 @@ public class ServletInfo {
   private long processingTime;
 
   /** The request count. */
-  private int requestCount;
+  private long requestCount;
 
   /** The single threaded. */
   private boolean singleThreaded;
@@ -188,7 +188,7 @@ public class ServletInfo {
    *
    * @return the error count
    */
-  public int getErrorCount() {
+  public long getErrorCount() {
     return errorCount;
   }
 
@@ -197,7 +197,7 @@ public class ServletInfo {
    *
    * @param errorCount the new error count
    */
-  public void setErrorCount(int errorCount) {
+  public void setErrorCount(long errorCount) {
     this.errorCount = errorCount;
   }
 
@@ -278,7 +278,7 @@ public class ServletInfo {
    *
    * @return the request count
    */
-  public int getRequestCount() {
+  public long getRequestCount() {
     return requestCount;
   }
 
@@ -287,7 +287,7 @@ public class ServletInfo {
    *
    * @param requestCount the new request count
    */
-  public void setRequestCount(int requestCount) {
+  public void setRequestCount(long requestCount) {
     this.requestCount = requestCount;
   }
 

--- a/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -170,11 +170,45 @@ public final class ApplicationUtils {
       if (container instanceof StandardWrapper) {
         StandardWrapper sw = (StandardWrapper) container;
         svltCount++;
-        reqCount += sw.getRequestCount();
-        errCount += sw.getErrorCount();
+
+        // Get Request Count (bridge between tomcat 10 and 11 using int vs long
+        Object requestCount = null;
+        try {
+          requestCount = MethodUtils.invokeMethod(sw, "getRequestCount");
+          if (requestCount instanceof Long) {
+            // tomcat 11+
+            reqCount += (long) requestCount;
+          } else {
+            // tomcat 10
+            reqCount += (int) requestCount;
+          }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+          logger.error("Unable to find getRequestCount", e);
+        }
+
+        // Get Error Count (bridge between tomcat 10 and 11 using int vs long
+        try {
+          Object errorCount = MethodUtils.invokeMethod(sw, "getErrorCount");
+          if (errorCount instanceof Long) {
+            // Tomcat 11+
+            errCount += (long) errorCount;
+          } else {
+            // Tomcat 10
+            errCount += (int) errorCount;
+          }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+          logger.error("Unable to find getErrorCount", e);
+        }
+
         procTime += sw.getProcessingTime();
-        if (sw.getRequestCount() > 0) {
-          minTime = Math.min(minTime, sw.getMinTime());
+        if (requestCount != null) {
+          if (requestCount instanceof Long && (long) requestCount > 0) {
+            // Tomcat 11+
+            minTime = Math.min(minTime, sw.getMinTime());
+          } else if (requestCount instanceof Integer && (int) requestCount > 0) {
+            // Tomcat 10
+            minTime = Math.min(minTime, sw.getMinTime());
+          }
         }
         maxTime = Math.max(maxTime, sw.getMaxTime());
       }
@@ -371,12 +405,40 @@ public final class ApplicationUtils {
     if (wrapper instanceof StandardWrapper) {
       StandardWrapper sw = (StandardWrapper) wrapper;
       si.setAllocationCount(sw.getCountAllocated());
-      si.setErrorCount(sw.getErrorCount());
+
+      // Get Error Count (bridge between tomcat 10 and 11 using int vs long
+      try {
+        Object errorCount = MethodUtils.invokeMethod(sw, "getErrorCount");
+        if (errorCount instanceof Long) {
+          // Tomcat 11+
+          si.setErrorCount((long) errorCount);
+        } else {
+          // Tomcat 10
+          si.setErrorCount((int) errorCount);
+        }
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        logger.error("Unable to find getErrorCount", e);
+      }
+
       si.setLoadTime(sw.getLoadTime());
       si.setMaxTime(sw.getMaxTime());
       si.setMinTime(sw.getMinTime() == Long.MAX_VALUE ? 0 : sw.getMinTime());
       si.setProcessingTime(sw.getProcessingTime());
-      si.setRequestCount(sw.getRequestCount());
+
+      // Get Request Count (bridge between tomcat 10 and 11 using int vs long
+      try {
+        Object requestCount = MethodUtils.invokeMethod(sw, "getRequestCount");
+        if (requestCount instanceof Long) {
+          // Tomcat 11+
+          si.setRequestCount((long) requestCount);
+        } else {
+          // Tomcat 10
+          si.setRequestCount((int) requestCount);
+        }
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        logger.error("Unable to find getRequestCount", e);
+      }
+
     }
     return si;
   }

--- a/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -238,16 +238,7 @@ public final class ApplicationUtils {
       sbean.setLastAccessTime(new Date(session.getLastAccessedTime()));
       sbean.setMaxIdleTime(session.getMaxInactiveInterval() * 1000);
       sbean.setManagerType(session.getManager().getClass().getName());
-
-      // Tomcat 8+ dropped support of getInfo off session. This patch allows it to continue working
-      // for tomcat 7.
-      try {
-        Object info = MethodUtils.invokeMethod(session, "getInfo");
-        sbean.setInfo(String.valueOf(info));
-      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        sbean.setInfo(session.getClass().getSimpleName());
-        logger.trace("Cannot determine session info for tomcat 8+", e);
-      }
+      sbean.setInfo(session.getClass().getSimpleName());
 
       boolean sessionSerializable = true;
       int attributeCount = 0;

--- a/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
+++ b/psi-probe-core/src/main/java/psiprobe/tools/ApplicationUtils.java
@@ -160,8 +160,8 @@ public final class ApplicationUtils {
    */
   public static void collectApplicationServletStats(Context context, Application app) {
     int svltCount = 0;
-    int reqCount = 0;
-    int errCount = 0;
+    long reqCount = 0;
+    long errCount = 0;
     long procTime = 0;
     long minTime = Long.MAX_VALUE;
     long maxTime = 0;


### PR DESCRIPTION
currently tomcat 11 fails.  These changes get it so that tomcat 11 will start but only a blank page is shown.

The tomcat7 removal piece was simply found during this as long overdue for removal.

Tomcat 10 continues to work as expected with this change.

Thanks to @Teutron-flo for help via #4037 to get to this point successfully with the additional reflection here so that tomcat 10 support is not broken.