### PR TITLE
Fix missing javascript on jsp page

### DIFF
--- a/psi-probe-web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
+++ b/psi-probe-web/src/main/webapp/WEB-INF/jsp/showjsps.jsp
@@ -22,6 +22,7 @@
         <title><spring:message htmlEscape="true" code="probe.jsp.title.jsps" arguments="${param.webapp}"/></title>
         <script src="<c:url value='/js/prototype.js'/>"></script>
         <script src="<c:url value='/js/scriptaculous/scriptaculous.js'/>"></script>
+        <script src="<c:url value='/js/func.js'/>"></script>
     </head>
 
     <c:set var="navTabApps" value="active" scope="request"/>


### PR DESCRIPTION
this was removed back in 2948f9267e3d31df487297e3ae82484f8fc4152a in 2016.  It was needed but surprising it took this long to even notice the issue.