### PR TITLE
Update coverity action

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -43,7 +43,6 @@ jobs:
         run: |
           wget --quiet https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_TOKEN}&project=${UPSTREAM_OWNER}%2F${UPSTREAM_REPO}" --output-document=coverity_tool.tgz
           tar --extract --file=coverity_tool.tgz
-          ./cov-analysis-linux64-*/bin/cov-build --version
           ./cov-analysis-linux64-*/bin/cov-build --dir cov-int ./mvnw verify --batch-mode --no-transfer-progress --show-version -Dlicense.skip=true -Dmaven.compiler.fork=true -DskipTests=true
           cat /home/runner/work/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/cov-int/build-log.txt
           tar --create --gzip --verbose --file=${UPSTREAM_REPO}.tgz cov-int


### PR DESCRIPTION
java 25 changed how it works and as a result, we need to force maven to fork the compilation.